### PR TITLE
AdsManager volume now syncs with player volume on ad start

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -198,6 +198,7 @@
             player.width(),
             player.height(),
             google.ima.ViewMode.NORMAL);
+        adsManager.setVolume(player.muted() ? 0 : player.volume());
         adsManager.start();
       } catch (adError) {
          player.ima.onAdError_(adError);


### PR DESCRIPTION
Fixes issue #6

https://github.com/googleads/videojs-ima/issues/6
