### PR TITLE
Revert "Update video.js references to 4.11.2 and ads-contrib to 0.5.0."

### DIFF
--- a/examples/advanced/index.html
+++ b/examples/advanced/index.html
@@ -16,7 +16,7 @@
 
 <html>
   <head>
-    <link href="//vjs.zencdn.net/4.11.2/video-js.css" rel="stylesheet">
+    <link href="//vjs.zencdn.net/4.7/video-js.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="../style.css"/>
     <link rel="stylesheet" href="../../third_party/videojs-ads/videojs.ads.css" />
     <link rel="stylesheet" href="../../src/videojs.ima.css" />
@@ -83,7 +83,7 @@
 
         <footer>Copyright (C) 2013 Google Inc.</footer>
     </div>
-    <script src="//vjs.zencdn.net/4.11.2/video.js"></script>
+    <script src="//vjs.zencdn.net/4.7/video.js"></script>
     <script src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
     <script src="../../third_party/videojs-ads/videojs.ads.js"></script>
     <script src="../../src/videojs.ima.js"></script>

--- a/examples/iPhone/index.html
+++ b/examples/iPhone/index.html
@@ -16,7 +16,7 @@
 
 <html>
   <head>
-    <link href="//vjs.zencdn.net/4.11.2/video-js.css" rel="stylesheet">
+    <link href="//vjs.zencdn.net/4.7/video-js.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="../style.css"/>
     <link rel="stylesheet" href="../../third_party/videojs-ads/videojs.ads.css" />
     <link rel="stylesheet" href="../../src/videojs.ima.css" />
@@ -78,7 +78,7 @@
 
         <footer>Copyright (C) 2013 Google Inc.</footer>
     </div>
-    <script src="//vjs.zencdn.net/4.11.2/video.js"></script>
+    <script src="//vjs.zencdn.net/4.7/video.js"></script>
     <script src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
     <script src="../../third_party/videojs-ads/videojs.ads.js"></script>
     <script src="../../src/videojs.ima.js"></script>

--- a/examples/playlist/index.html
+++ b/examples/playlist/index.html
@@ -16,7 +16,7 @@
 
 <html>
   <head>
-    <link href="//vjs.zencdn.net/4.11.2/video-js.css" rel="stylesheet">
+    <link href="//vjs.zencdn.net/4.7/video-js.css" rel="stylesheet">
     <link href="../style.css" rel="stylesheet">
     <link rel="stylesheet" href="../../third_party/videojs-ads/videojs.ads.css" />
     <link rel="stylesheet" href="../../src/videojs.ima.css" />
@@ -94,7 +94,7 @@
 
       <footer>Copyright (C) 2013 Google Inc.</footer>
     </div>
-    <script src="//vjs.zencdn.net/4.11.2/video.js"></script>
+    <script src="//vjs.zencdn.net/4.7/video.js"></script>
     <script src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
     <script src="../../third_party/videojs-ads/videojs.ads.js"></script>
     <script src="../../src/videojs.ima.js"></script>

--- a/examples/simple/index.html
+++ b/examples/simple/index.html
@@ -17,7 +17,7 @@
 <html>
   <head>
     <title>Video.js Test</title>
-    <link href="//vjs.zencdn.net/4.11.2/video-js.css" rel="stylesheet">
+    <link href="//vjs.zencdn.net/4.7/video-js.css" rel="stylesheet">
     <link rel="stylesheet" href="../../third_party/videojs-ads/videojs.ads.css" />
     <link rel="stylesheet" href="../../src/videojs.ima.css" />
     <link rel="stylesheet" href="../style.css" />
@@ -30,7 +30,7 @@
       <source src="http://rmcdn.2mdn.net/Demo/vast_inspector/android.mp4"
           type="video/mp4" ></source>
     </video>
-    <script src="//vjs.zencdn.net/4.11.2/video.js"></script>
+    <script src="//vjs.zencdn.net/4.7/video.js"></script>
     <script src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
     <script src="../../third_party/videojs-ads/videojs.ads.js"></script>
     <script src="../../src/videojs.ima.js"></script>

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "test": "python -m SimpleHTTPServer"
   },
   "dependencies": {
-    "video.js": "~4.11",
-    "videojs-contrib-ads": "~0.5.0"
+    "video.js": "~4.4",
+    "videojs-contrib-ads": "~0.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This broke ads on iPad. Going to revert, figure out the problem, then re-merge.

Reverts googleads/videojs-ima#36
