### PR TITLE
Fixed overlay issue

### DIFF
--- a/src/videojs.ima.css
+++ b/src/videojs.ima.css
@@ -24,6 +24,7 @@
   bottom:0px;
   height: 37px;
   position: absolute;
+  display: none;
   opacity: 1;
   background-color: rgba(7, 20, 30, .7);
   background: -moz-linear-gradient(

--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -53,7 +53,6 @@
               document.createElement('div'),
               vjsControls.el());
       adContainerDiv.id = 'ima-ad-container';
-      adContainerDiv.style.display = 'none';
       adContainerDiv.style.width = player.width() + 'px';
       adContainerDiv.style.height = player.height() + 'px';
       adContainerDiv.addEventListener(
@@ -247,6 +246,7 @@
         player.ads.startLinearAdMode();
       }
       adContainerDiv.style.display = 'block';
+      controlsDiv.style.display = 'block';
       vjsControls.hide();
       player.pause();
     };


### PR DESCRIPTION
Fixed overlay issue

Issue was that ad container was display:none when IMA tried to show the overlay ad. Fix is to leave the ad container as visible upon creation, and hide the controls div instead of the entire ad container. We still need to show/hide the ad container for controls access on iPad.
