### PR TITLE
Don't auto play on error

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -217,7 +217,6 @@
       if (adsManager) {
         adsManager.destroy();
       }
-      player.play();
     };
 
     /**


### PR DESCRIPTION
As errors also include no ads, and we don't have autoplay on our videos, setting the video to play on error seems rather prescriptive

Simply leaving it to the client, listening to the `adtimeout` event, to decide what to do seems most appropriate