### PR TITLE
trigger "adserror" event and let ads-plugin resume play

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -217,7 +217,7 @@
       if (adsManager) {
         adsManager.destroy();
       }
-      player.play();
+      player.trigger('adserror');
     };
 
     /**
@@ -230,7 +230,7 @@
       window.console.log('Ad error: ' + adErrorEvent.getError());
       adsManager.destroy();
       adContainerDiv.style.display = 'none';
-      player.play();
+      player.trigger('adserror');
     };
 
     /**

--- a/test/videojs.ima.test.js
+++ b/test/videojs.ima.test.js
@@ -30,8 +30,8 @@ test('video plays on bad ad tag', function() {
   player.play();
   stop();
   setTimeout(function() {
-    // Play called once by us and once by the plugin on error.
-    equal(2, playCount);
+    // Play called once by the plugin on error.
+    equal(playCount, 1);
     start();
   }, 5000);
 });
@@ -54,7 +54,7 @@ test('ad plays on good ad tag', function() {
   player.play();
   stop();
   setTimeout(function() {
-    equal(1, contentPauseCount);
+    equal(contentPauseCount, 1);
     start();
   }, 5000);
 });


### PR DESCRIPTION
Ad-integrations are supposed to trigger 'adserror' events as soon as they catch errors. The ads-plugin then resumes playback.

> adserror (EVENT) - Trigger this event to indicate that an error in the ad integration has ocurred and any ad states should abort so that content can resume.

This pull-request adds this trigger. The play-call is not necessary then anymore.