### PR TITLE
pass timeout/prerollTimout settings to contrib.ads

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -35,6 +35,9 @@
   },
 
   defaults = {
+    debug: false,
+    timeout: 5000,
+    prerollTimeout: 100
   },
 
   imaPlugin = function(options, readyCallback) {
@@ -820,7 +823,11 @@
 
     player.on('ended', localContentEndedListener);
 
-    player.ads({debug: settings.debug});
+    player.ads({
+      debug: settings.debug,
+      timeout: settings.timeout,
+      prerollTimeout: settings.prerollTimeout
+    });
 
     adsRenderingSettings = new google.ima.AdsRenderingSettings();
     adsRenderingSettings.restoreCustomPlaybackStateOnAdBreakComplete = true;


### PR DESCRIPTION
to improve our UX we need to tweak the timeout and prerollTimeout settings of the videojs.contrib.ads plugin. This pull request uses the same defaults as the ads plugin and just passes them through unless you pass in your own settings.