### PR TITLE
Updated for video.js 4.12 and contrib-ads 1.1

### DIFF
--- a/examples/advanced/ads.js
+++ b/examples/advanced/ads.js
@@ -21,7 +21,8 @@ var Ads = function() {
   // Remove controls from the player on iPad to stop native controls from stealing
   // our click
   var contentPlayer =  document.getElementById('content_video_html5_api');
-  if (navigator.userAgent.match(/iPad/i) != null &&
+  if ((navigator.userAgent.match(/iPad/i) ||
+          navigator.userAgent.match(/Android/i)) &&
       contentPlayer.hasAttribute('controls')) {
     contentPlayer.removeAttribute('controls');
   }
@@ -29,7 +30,13 @@ var Ads = function() {
   // Start ads when the video player is clicked, but only the first time it's
   // clicked.
   this.clickedOnce = false;
-  this.player.on('click', this.bind(this, function() {
+  var startEvent = 'click';
+  if (navigator.userAgent.match(/iPhone/i) ||
+      navigator.userAgent.match(/iPad/i) ||
+      navigator.userAgent.match(/Android/i)) {
+    startEvent = 'tap';
+  }
+  this.player.on(startEvent, this.bind(this, function() {
       if (!this.clickedOnce) {
         this.init();
         this.clickedOnce = true;

--- a/examples/advanced/index.html
+++ b/examples/advanced/index.html
@@ -16,7 +16,7 @@
 
 <html>
   <head>
-    <link href="//vjs.zencdn.net/4.7/video-js.css" rel="stylesheet">
+    <link href="//vjs.zencdn.net/4.12/video-js.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="../style.css"/>
     <link rel="stylesheet" href="../../third_party/videojs-ads/videojs.ads.css" />
     <link rel="stylesheet" href="../../src/videojs.ima.css" />
@@ -83,7 +83,7 @@
 
         <footer>Copyright (C) 2013 Google Inc.</footer>
     </div>
-    <script src="//vjs.zencdn.net/4.7/video.js"></script>
+    <script src="//vjs.zencdn.net/4.12/video.js"></script>
     <script src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
     <script src="../../third_party/videojs-ads/videojs.ads.js"></script>
     <script src="../../src/videojs.ima.js"></script>

--- a/examples/iPhone/ads.js
+++ b/examples/iPhone/ads.js
@@ -15,9 +15,6 @@
  */
 
 var Ads = function() {
-  // Create player and start ads when the video player is clicked, but only the
-  // first time it's clicked.
-  this.clickedOnce = false;
   this.placeholder = document.getElementById('ima-sample-placeholder');
   this.placeholder.addEventListener('click', this.bind(this, this.init));
 

--- a/examples/iPhone/index.html
+++ b/examples/iPhone/index.html
@@ -16,7 +16,7 @@
 
 <html>
   <head>
-    <link href="//vjs.zencdn.net/4.7/video-js.css" rel="stylesheet">
+    <link href="//vjs.zencdn.net/4.12/video-js.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="../style.css"/>
     <link rel="stylesheet" href="../../third_party/videojs-ads/videojs.ads.css" />
     <link rel="stylesheet" href="../../src/videojs.ima.css" />
@@ -78,7 +78,7 @@
 
         <footer>Copyright (C) 2013 Google Inc.</footer>
     </div>
-    <script src="//vjs.zencdn.net/4.7/video.js"></script>
+    <script src="//vjs.zencdn.net/4.12/video.js"></script>
     <script src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
     <script src="../../third_party/videojs-ads/videojs.ads.js"></script>
     <script src="../../src/videojs.ima.js"></script>

--- a/examples/playlist/ads.js
+++ b/examples/playlist/ads.js
@@ -21,7 +21,8 @@ var Ads = function() {
   // Remove controls from the player on iPad to stop native controls from stealing
   // our click
   var contentPlayer =  document.getElementById('content_video_html5_api');
-  if (navigator.userAgent.match(/iPad/i) != null &&
+  if ((navigator.userAgent.match(/iPad/i) ||
+          navigator.userAgent.match(/Android/i)) &&
       contentPlayer.hasAttribute('controls')) {
     contentPlayer.removeAttribute('controls');
   }
@@ -29,7 +30,13 @@ var Ads = function() {
   // Start ads when the video player is clicked, but only the first time it's
   // clicked.
   this.clickedOnce = false;
-  this.player.on('click', this.bind(this, function() {
+  var startEvent = 'click';
+  if (navigator.userAgent.match(/iPhone/i) ||
+      navigator.userAgent.match(/iPad/i) ||
+      navigator.userAgent.match(/Android/i)) {
+    startEvent = 'tap';
+  }
+  this.player.on(startEvent, this.bind(this, function() {
       if (!this.clickedOnce) {
         this.init();
         this.clickedOnce = true;

--- a/examples/playlist/index.html
+++ b/examples/playlist/index.html
@@ -16,7 +16,7 @@
 
 <html>
   <head>
-    <link href="//vjs.zencdn.net/4.7/video-js.css" rel="stylesheet">
+    <link href="//vjs.zencdn.net/4.12/video-js.css" rel="stylesheet">
     <link href="../style.css" rel="stylesheet">
     <link rel="stylesheet" href="../../third_party/videojs-ads/videojs.ads.css" />
     <link rel="stylesheet" href="../../src/videojs.ima.css" />
@@ -94,7 +94,7 @@
 
       <footer>Copyright (C) 2013 Google Inc.</footer>
     </div>
-    <script src="//vjs.zencdn.net/4.7/video.js"></script>
+    <script src="//vjs.zencdn.net/4.12/video.js"></script>
     <script src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
     <script src="../../third_party/videojs-ads/videojs.ads.js"></script>
     <script src="../../src/videojs.ima.js"></script>

--- a/examples/simple/ads.js
+++ b/examples/simple/ads.js
@@ -30,7 +30,8 @@ player.ima(options);
 // Remove controls from the player on iPad to stop native controls from stealing
 // our click
 var contentPlayer =  document.getElementById('content_video_html5_api');
-if (navigator.userAgent.match(/iPad/i) != null &&
+if ((navigator.userAgent.match(/iPad/i) ||
+      navigator.userAgent.match(/Android/i)) &&
     contentPlayer.hasAttribute('controls')) {
   contentPlayer.removeAttribute('controls');
 }
@@ -38,7 +39,13 @@ if (navigator.userAgent.match(/iPad/i) != null &&
 // Initialize the ad container when the video player is clicked, but only the
 // first time it's clicked.
 var clickedOnce = false;
-player.on('click', function() {
+var startEvent = 'click';
+if (navigator.userAgent.match(/iPhone/i) ||
+    navigator.userAgent.match(/iPad/i) ||
+    navigator.userAgent.match(/Android/i)) {
+  startEvent = 'tap';
+}
+player.on(startEvent, function() {
     if (!clickedOnce) {
       player.ima.initializeAdDisplayContainer();
       player.ima.requestAds();

--- a/examples/simple/index.html
+++ b/examples/simple/index.html
@@ -17,7 +17,7 @@
 <html>
   <head>
     <title>Video.js Test</title>
-    <link href="//vjs.zencdn.net/4.7/video-js.css" rel="stylesheet">
+    <link href="//vjs.zencdn.net/4.12/video-js.css" rel="stylesheet">
     <link rel="stylesheet" href="../../third_party/videojs-ads/videojs.ads.css" />
     <link rel="stylesheet" href="../../src/videojs.ima.css" />
     <link rel="stylesheet" href="../style.css" />
@@ -30,7 +30,7 @@
       <source src="http://rmcdn.2mdn.net/Demo/vast_inspector/android.mp4"
           type="video/mp4" ></source>
     </video>
-    <script src="//vjs.zencdn.net/4.7/video.js"></script>
+    <script src="//vjs.zencdn.net/4.12/video.js"></script>
     <script src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
     <script src="../../third_party/videojs-ads/videojs.ads.js"></script>
     <script src="../../src/videojs.ima.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-ima",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "./src/videojs.ima.js",
   "author": {
     "name": "Google Inc."
@@ -12,8 +12,8 @@
     "test": "python -m SimpleHTTPServer"
   },
   "dependencies": {
-    "video.js": "~4.4",
-    "videojs-contrib-ads": "~0.2.0"
+    "video.js": "~4.12",
+    "videojs-contrib-ads": "~1.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This behaves a little bit differently than the old video.js and contrib-ads versions on mobile, and I don't know if everyone will like it. To compensate for that I've tagged the current stuff 0.1.0 and will release the below merge as 0.2.0.