### PR TITLE
check if tech is loaded before set src

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -544,7 +544,10 @@
         function( contentSrc, adTag, playOnLoad) {
       player.ima.resetIMA_();
       settings.adTagUrl = adTag ? adTag : settings.adTagUrl;
-      player.pause();
+      //only try to pause the player when initialised with a source already
+      if (!!player.currentSrc()) {
+        player.pause();
+      }
       if (contentSrc) {
         player.src(contentSrc);
       }


### PR DESCRIPTION
In cases where no source is loaded upfront, no tech is available. Thus the first time you want to use player.ima.setContent(), player.pause() will break.