### PR TITLE
properly bind loadedmetadata event handlers

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -549,13 +549,9 @@
         player.src(contentSrc);
       }
       if (playOnLoad) {
-        player.on('loadedmetadata', function() {
-          player.ima.playContentFromZero_();
-        });
+        player.on('loadedmetadata', player.ima.playContentFromZero_);
       } else {
-        player.on('loadedmetadata', function() {
-          player.ima.seekContentToZero_();
-        });
+        player.on('loadedmetadata', player.ima.seekContentToZero_);
       }
     };
 


### PR DESCRIPTION
you can only use player.off('event', refToFunction) when you used player.on('event', refToFunction) before...