### PR TITLE
Added CSS to bump overlay when vjs-user-active is not present.

### DIFF
--- a/src/videojs.ima.css
+++ b/src/videojs.ima.css
@@ -20,6 +20,11 @@
   display: block;
 }
 
+/* Move overlay if user fast-clicks play button. */
+.video-js.vjs-playing .bumpable-ima-ad-container {
+  margin-top: -40px;
+}
+
 /* Move overlay when controls are active. */
 .video-js.vjs-user-inactive.vjs-playing .bumpable-ima-ad-container {
   margin-top: 0px;


### PR DESCRIPTION
When the user loads the page and very quickly clicks the play button, video.js does not add the vjs-user-active class we rely on to bump nonlinear ads from behind the controls. This CSS addition handles that use case. Fixes #69 