### PR TITLE
Ad Controls Remain Hidden After VAST Error

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -266,6 +266,7 @@
      */
     player.ima.onAdError_ = function(adErrorEvent) {
       window.console.log('Ad error: ' + adErrorEvent.getError());
+      vjsControls.show();
       adsManager.destroy();
       adContainerDiv.style.display = 'none';
       player.trigger('adserror');


### PR DESCRIPTION
Ad controls remain hidden after a VAST error. This ensures they are set to show again.