### PR TITLE
seekbar width fix

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -85,7 +85,7 @@
       countdownDiv.style.display = showCountdown ? 'block' : 'none';
       seekBarDiv = document.createElement('div');
       seekBarDiv.id = 'ima-seek-bar-div';
-      seekBarDiv.style.width = player.width() + 'px';
+      seekBarDiv.style.width = '100%';
       progressDiv = document.createElement('div');
       progressDiv.id = 'ima-progress-div';
       playPauseDiv = document.createElement('div');


### PR DESCRIPTION
When enter fullscreen (or changed player width with other ways e.g js api or css) on showing adsense then seekbar width equals to player's initial width.