### PR TITLE
Set nonLinear size to player size

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -159,10 +159,8 @@
 
       adsRequest.linearAdSlotWidth = player.width();
       adsRequest.linearAdSlotHeight = player.height();
-      adsRequest.nonLinearAdSlotWidth =
-          settings.nonLinearWidth || player.width();
-      adsRequest.nonLinearAdSlotHeight =
-          settings.nonLinearHeight || (player.height() / 3);
+      adsRequest.nonLinearAdSlotWidth = player.width();
+      adsRequest.nonLinearAdSlotHeight = player.height();
 
       adsLoader.requestAds(adsRequest);
     };


### PR DESCRIPTION
nonLinearAdSlotWidth and nonLinearSlotHeight must be equal to player size. Otherwise, modal ads (below the picture) not returned because player.height() / 3. This is a nonLinear ads, its not like it seems.
Additionally, if nonLinearWidth and nonLinearHeight is provided like this:
```
var options = {
  id: 'content_video',
  adTagUrl: 'http://pubads.g.doubleclick.net/gampad/ads?sz=640x480&' +
      'iu=/124319096/external/ad_rule_samples&ciu_szs=300x250&ad_rule=1&' +
      'impl=s&gdfp_req=1&env=vp&output=xml_vmap1&unviewed_position_start=1&' +
      'cust_params=sample_ar%3Dpremidpostpod%26deployment%3Dgmf-js&cmsid=496&' +
      'vid=short_onecue&correlator=',
  'nonLinearWidth': player.width(),
  'nonLinearHeight': player.height()
};
player.ima(options);
```
and changed player size with video.js api at runtime then these settings is not updated in the videojs-ima plugin.
<img width="638" alt="ebf51376-b3e0-11e5-8e23-74b58f0d599f" src="https://cloud.githubusercontent.com/assets/5111036/12165934/9fc2b1b6-b52a-11e5-80dc-fa596a301e3a.png">