### PR TITLE
Pause removed from setContent

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -676,10 +676,6 @@
         function(contentSrc, adTag, playOnLoad) {
       player.ima.resetIMA_();
       settings.adTagUrl = adTag ? adTag : settings.adTagUrl;
-      //only try to pause the player when initialised with a source already
-      if (!!player.currentSrc()) {
-        player.pause();
-      }
       if (contentSrc) {
         player.src(contentSrc);
       }


### PR DESCRIPTION
When call setContent for the midroll (for example, 10 sec. on content video) player paused. This is problem for nonlinear ads on the midroll. Because player paused a short time before the nonlinear ads and then play again.