### PR TITLE
passing through numRedirects setting to ima-sdk

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -1093,6 +1093,10 @@
       adsLoader.getSettings().setLocale(settings.locale);
     }
 
+    if (settings.numRedirects) {
+      adsLoader.getSettings().setNumRedirects(settings.numRedirects);
+    }
+
     adsLoader.getSettings().setPlayerType('videojs-ima');
     adsLoader.getSettings().setPlayerVersion(VERSION);
     adsLoader.getSettings().setAutoPlayAdBreaks(autoPlayAdBreaks);


### PR DESCRIPTION
We need this setting to be able to increase the number of redirects allowed for VAST. 
https://developers.google.com/interactive-media-ads/docs/sdks/html5/v3/apis#ima.ImaSdkSettings.setNumRedirects