### PR TITLE
Bower manifest for 0.3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,15 @@
+{
+  "name": "videojs-ima",
+  "main": "./src/videojs.ima.js",
+  "authors": [
+    "Google Inc."
+  ],
+  "dependencies": {
+    "video.js": "~5.3",
+    "videojs-contrib-ads": "~3.1.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/googleads/videojs-ima"
+  }
+}


### PR DESCRIPTION
In response to #28 never being accepted. I've signed the Google Individual CLA.

#### Pre accepting:
To test manifest using my git endpoint (on bower branch):
```ssh
bower install git@github.com:steevee/videojs-ima.git#bower
```

#### Post accepting:
To test manifest using package maintainer's git endpoint:
```ssh
bower install git@github.com:googleads/videojs-ima.git
```

To register publicly with Bower:
```ssh
bower register videojs-ima git@github.com:googleads/videojs-ima.git
```

To test registration:
```ssh
bower install videojs-ima
```