### PR TITLE
bind events on player after it is ready

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -1134,8 +1134,10 @@
       readyCallback = player.ima.start;
     }
     player.on('readyforpreroll', readyCallback);
-    player.on('fullscreenchange', player.ima.onFullscreenChange_);
-    player.on('volumechange', player.ima.onVolumeChange_);
+    player.ready(function() {
+      player.on('fullscreenchange', player.ima.onFullscreenChange_);
+      player.on('volumechange', player.ima.onVolumeChange_);
+    });
   };
 
   videojs.plugin('ima', imaPlugin);


### PR DESCRIPTION
This gives the player time to do it's own work before the plugin handles the event.

There is a case where on the `fullscreenchange` event videojs toggles the `vjs-fullscreen` class. If the plugin handler runs before that, the values of ima.height() is wrong (is 0) when player is using the intrinsic ratio class (`.vjs-16-9`) for it's dimensions.