### PR TITLE
Hide the container if AdLoaderError is fired

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -249,6 +249,7 @@
       if (adsManager) {
         adsManager.destroy();
       }
+      adContainerDiv.style.display = 'none';
       player.trigger('adserror');
     };
 


### PR DESCRIPTION
If an AdLoaderError is fired, despite playing the video normally, none of the controls are clickable, because the adContainerDiv is still present on top. This commit hides the container