### PR TITLE
Add data from AdError and AdErrorEvent on adserror

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -252,7 +252,7 @@
       if (adsManager) {
         adsManager.destroy();
       }
-      player.trigger('adserror');
+      player.trigger({type: 'adserror', data: { AdError: event.getError(), AdErrorEvent: event }});
     };
 
     /**
@@ -266,7 +266,7 @@
       vjsControls.show();
       adsManager.destroy();
       adContainerDiv.style.display = 'none';
-      player.trigger('adserror');
+      player.trigger({ type: 'adserror', data: { AdError: adErrorEvent.getError(), AdErrorEvent: adErrorEvent }});
     };
 
     /**

--- a/test/videojs.ima.test.js
+++ b/test/videojs.ima.test.js
@@ -1,15 +1,13 @@
 var video, player;
+var setup = function() {
+  video = document.createElement('video');
+  video.id = 'video';
+  document.getElementById('qunit-fixture').appendChild(video);
+  player = videojs(video);
+};
 
-module('Ad Framework', {
-  setup: function() {
-    video = document.createElement('video');
-    video.id = 'video';
-    document.getElementById('qunit-fixture').appendChild(video);
-    player = videojs(video);
-  },
-  teardown: function() {
-  }
-});
+
+module('Ad Framework', { setup: setup });
 
 test('the environment is sane', function() {
   ok(true, 'true is ok');
@@ -99,4 +97,61 @@ test('video continues after ad was skipped', function() {
     equal(adCompleteCount, 1 , 'adComplete was called');
     start();
   }, 6000);
+});
+
+
+module("Events", { setup: setup });
+
+test('onAdsLoaderError_ should trigger adserror with data from google.ima.AdError and google.ima.AdErrorEvent', function() {
+  var options = {
+    id: 'video',
+    adTagUrl: ''
+  };
+
+  player.on("adserror", function(event){
+    deepEqual(Object.keys(Object(event.data)), ["AdError", "AdErrorEvent"], "event.data should have AdError and AdErrorEvent");
+
+    if (event.data) {
+      ok(event.data.AdError, "AdError should be defined");
+      ok(event.data.AdErrorEvent, "AdErrorEvent should be defined");
+    }
+
+    start();
+  });
+
+  player.ima(options);
+  player.ima.requestAds();
+
+  stop();
+});
+
+test('onAdError_ should trigger adserror with data from google.ima.AdError and google.ima.AdErrorEvent', function() {
+  // stub view mode to throw on start
+  google.ima.ViewMode.NORMAL = "throw-on-ads-manager-init";
+
+  var options = {
+    id: 'video',
+    adTagUrl: 'http://pubads.g.doubleclick.net/gampad/ads?sz=640x360&' +
+        'iu=/6062/iab_vast_samples/skippable&ciu_szs=300x250,728x90&impl=s&' +
+        'gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&' +
+        'url=[referrer_url]&correlator=[timestamp]',
+    autoPlayAdBreaks: true,
+  };
+
+  player.on("adserror", function(event){
+    deepEqual(Object.keys(Object(event.data)), ["AdError", "AdErrorEvent"], "event.data should have AdError and AdErrorEvent");
+
+    if (event.data) {
+      ok(event.data.AdError, "AdError should be defined");
+      ok(event.data.AdErrorEvent, "AdErrorEvent should be defined");
+    }
+
+    start();
+  });
+
+  player.ima(options);
+  player.ima.requestAds();
+  player.play();
+
+  stop();
 });


### PR DESCRIPTION
Error events are triggered without any specific information regarding the error, therefore clients can't debug if something's wrong with the ad integration. I propose adding `data` attribute into the dispatched event with attributes, which are: `AdError` and `AdErrorEvent`.

Following is an example of how to use this patch.

```
player.on("adserror", function(event){
  console.log(event.data.AdError) // prints google.ima.AdError object
  console.log(event.data.AdErrorEvent) // prints google.ima.AdErrorEvent object
});
```

I am currently implementing a client using videojs-ima integration, and have a hard time of debugging issues and collecting adserror related information. I hope this patch can be accepted, tests are included.

I have also submitted the corporate CLA, I'm not sure if you have received it. Please let me know if there's anything more I have to add.