### PR TITLE
Replace reference to deprecated `player.ima.start()`

### DIFF
--- a/examples/iPhone/ads.js
+++ b/examples/iPhone/ads.js
@@ -78,7 +78,7 @@ Ads.prototype.adsManagerLoadedCallback = function() {
         this.events[index],
         this.bind(this, this.onAdEvent));
   }
-  this.player.ima.start();
+  this.player.ima.startFromReadyCallback();
 };
 
 Ads.prototype.onAdEvent = function(event) {

--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -149,7 +149,7 @@
       if (settings.adTagUrl) {
         adsRequest.adTagUrl = settings.adTagUrl;
       } else {
-        adsRequest.adsResponse = adsResponse;
+        adsRequest.adsResponse = settings.adsResponse;
       }
       if (settings.forceNonLinearFullSlot) {
         adsRequest.forceNonLinearFullSlot = true;


### PR DESCRIPTION
The old reference was preventing me from diagnosing iOS issues with the iPhone example.