### PR TITLE
Swapped out deprecated func

### DIFF
--- a/examples/iPhone/ads.js
+++ b/examples/iPhone/ads.js
@@ -78,7 +78,7 @@ Ads.prototype.adsManagerLoadedCallback = function() {
         this.events[index],
         this.bind(this, this.onAdEvent));
   }
-  this.player.ima.start();
+  this.player.ima.startFromReadyCallback();
 };
 
 Ads.prototype.onAdEvent = function(event) {


### PR DESCRIPTION
The old reference was preventing me from diagnosing iOS issues with the iPhone example.