### PR TITLE
Fix blinking of the control bar

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -60,11 +60,11 @@
       adContainerDiv.style.position = "absolute";
       adContainerDiv.style.zIndex = 1111;
       adContainerDiv.addEventListener(
-          'mouseover',
+          'mouseenter',
           player.ima.showAdControls_,
           false);
       adContainerDiv.addEventListener(
-          'mouseout',
+          'mouseleave',
           player.ima.hideAdControls_,
           false);
       player.ima.createControls_();

--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -473,10 +473,11 @@
      * @private
      */
     player.ima.hideAdControls_ = function() {
+      controlsDiv.style.height = '14px';
       playPauseDiv.style.display = 'none';
       muteDiv.style.display = 'none';
+      sliderDiv.style.display = 'none';
       fullscreenDiv.style.display = 'none';
-      controlsDiv.style.height = '14px';
     };
 
     /**


### PR DESCRIPTION
Using `moseover` and `mouseout` events on `#ima-ad-container` causes blinking of `#ima-controls-div` when cursor is moved onto the `#ima-ad-container` children (when user moves cursor onto the control bar).