### PR TITLE
newVolume was referenced to this, but is a local variable

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -696,7 +696,7 @@
         this.adsManager.setVolume(newVolume);
       }
       // Update UI
-      if (this.newVolume == 0) {
+      if (newVolume == 0) {
         this.adMuted = true;
         addClass_(this.muteDiv, 'ima-muted');
         removeClass_(this.muteDiv, 'ima-non-muted');


### PR DESCRIPTION
In some instances when mute was pressed, it would change back to unmute. This fixes this issue.