### PR TITLE
Fix for play/pause not resting when starting a new video

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -696,7 +696,7 @@
         this.adsManager.setVolume(newVolume);
       }
       // Update UI
-      if (this.newVolume == 0) {
+      if (newVolume == 0) {
         this.adMuted = true;
         addClass_(this.muteDiv, 'ima-muted');
         removeClass_(this.muteDiv, 'ima-non-muted');

--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -376,6 +376,7 @@
      */
     this.onContentPauseRequested_ = function(adEvent) {
       this.adsActive = true;
+      this.resumeAd();
       this.adPlaying = true;
       this.player.off('ended', this.localContentEndedListener);
       if (adEvent.getAd().getAdPodInfo().getPodIndex() != -1) {

--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -376,7 +376,6 @@
      */
     this.onContentPauseRequested_ = function(adEvent) {
       this.adsActive = true;
-      this.resumeAd();
       this.adPlaying = true;
       this.player.off('ended', this.localContentEndedListener);
       if (adEvent.getAd().getAdPodInfo().getPodIndex() != -1) {
@@ -393,6 +392,7 @@
       }
 
       this.vjsControls.hide();
+      showPlayButton();
       this.player.pause();
     }.bind(this);
 
@@ -553,18 +553,32 @@
     }.bind(this);
 
     /**
+     * Show pause and hide play button
+     */
+    var showPauseButton = function() {
+      addClass_(this.playPauseDiv, 'ima-paused');
+      removeClass_(this.playPauseDiv, 'ima-playing');
+    }.bind(this);
+
+    /**
+     * Show play and hide pause button
+     */
+    var showPlayButton = function() {
+      addClass_(this.playPauseDiv, 'ima-playing');
+      removeClass_(this.playPauseDiv, 'ima-paused');
+    }.bind(this);
+
+    /**
      * Listener for clicks on the play/pause button during ad playback.
      * @private
      */
     var onAdPlayPauseClick_ = function() {
       if (this.adPlaying) {
-        addClass_(this.playPauseDiv, 'ima-paused');
-        removeClass_(this.playPauseDiv, 'ima-playing');
+        showPauseButton();
         this.adsManager.pause();
         this.adPlaying = false;
       } else {
-        addClass_(this.playPauseDiv, 'ima-playing');
-        removeClass_(this.playPauseDiv, 'ima-paused');
+        showPlayButton();
         this.adsManager.resume();
         this.adPlaying = true;
       }
@@ -895,8 +909,7 @@
      */
     this.pauseAd = function() {
       if (this.adsActive && this.adPlaying) {
-        addClass_(this.playPauseDiv, 'ima-paused');
-        removeClass_(this.playPauseDiv, 'ima-playing');
+        showPauseButton();
         this.adsManager.pause();
         this.adPlaying = false;
       }
@@ -907,8 +920,7 @@
      */
     this.resumeAd = function() {
       if (this.adsActive && !this.adPlaying) {
-        addClass_(this.playPauseDiv, 'ima-playing');
-        removeClass_(this.playPauseDiv, 'ima-paused');
+        showPlayButton();
         this.adsManager.resume();
         this.adPlaying = true;
       }


### PR DESCRIPTION
If a new video is started while an ad is paused, the play icon is not reset to a pause icon.

To reproduce change this

``` javascript
Ads.prototype.onPlaylistItemClick = function(event) {
  if (!this.linearAdPlaying) {
    this.player.ima.setContentWithAdTag(
        this.contents[event.target.id],
        null,
        true);
    this.player.poster(this.posters[event.target.id]);
    this.player.ima.requestAds();
  }
};
```

To this

``` javascript
Ads.prototype.onPlaylistItemClick = function(event) {
  //if (!this.linearAdPlaying) {
    this.player.ima.setContentWithAdTag(
        this.contents[event.target.id],
        null,
        true);
    this.player.poster(this.posters[event.target.id]);
    this.player.ima.requestAds();
  //}
};
```

In the playlist example 

Start the clip -> pause the ad -> click the next clip -> its now showing a play icon

The fix works, but i'm not sure it doesn't have any side effects. 