### PR TITLE
Updating test suite to fix 404s (videojs-contrib-ads)

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -9,8 +9,7 @@
     <link rel="stylesheet" href="//code.jquery.com/qunit/qunit-1.14.0.css">
     <script src="//code.jquery.com/qunit/qunit-1.14.0.js"></script>
     <!-- Load videojs-contrib-ads -->
-    <link rel="stylesheet" href="//rawgit.com/videojs/videojs-contrib-ads/master/src/videojs.ads.css">
-    <script src="//rawgit.com/videojs/videojs-contrib-ads/master/src/videojs.ads.js"></script>
+    <script src="../node_modules/videojs-contrib-ads/dist/videojs.ads.js"></script>
     <!-- Load IMA library -->
     <script src="//s0.2mdn.net/instream/html5/ima3_debug.js"></script>
     <!-- Load local IMA plugin -->


### PR DESCRIPTION
While forking this repo, I ran `npm install` and `bower install`

Booted up the test suite, and all had failed due to `rawgit` returning 404s. It looks like their repo (videojs-contrib-ads) requires you to build the plugin vs having it committed to git.

## Secondary Suggestion
Can we get a release to bower / node? I had actually forked to get the `dispose` events going so the intervals would get cleaned up and it happened to be in master. Going to use the last commit in bower for now, but would love an actual release.

![_video_js_ima_plugin_test_suite](https://cloud.githubusercontent.com/assets/1273570/20149862/b44516c0-a678-11e6-888c-6f6099f01cf3.png)
