### PR TITLE
Adding a clear timeout when player is destroyed

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -1286,6 +1286,12 @@
       this.contentEndedListeners, this.contentAndAdsEndedListeners = [], [];
       this.contentComplete = true;
       this.player.off('ended', this.localContentEndedListener);
+
+      // Bug fix: https://github.com/googleads/videojs-ima/issues/306
+      if (this.player.ads.adTimeoutTimeout) {
+        clearTimeout(this.player.ads.adTimeoutTimeout);
+      }
+
       var intervalsToClear = [this.updateTimeIntervalHandle, this.seekCheckIntervalHandle,
         this.adTrackingTimer, this.resizeCheckIntervalHandle];
       for (var index in intervalsToClear) {


### PR DESCRIPTION
Fixes https://github.com/googleads/videojs-ima/issues/306

Test Suite:
![_video_js_ima_plugin_test_suite_](https://cloud.githubusercontent.com/assets/1273570/20218000/25a2a916-a7e8-11e6-990c-4a6a8a80f71b.png)
