### PR TITLE
After postroll play, no media found bug occurs

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -444,9 +444,12 @@
       this.allAdsCompleted = true;
       this.adContainerDiv.style.display = 'none';
       if (this.contentComplete == true) {
-        if (this.contentPlayer.src != this.contentSource) {
-          this.player.src(this.contentSource);
+
+        //To prevent the error if contentSource is empty
+        if (typeof this.contentSource == 'string' && this.contentSource.length > 0 && this.contentPlayer.src != this.contentSource) {
+            this.player.src(this.contentSource);
         }
+
         for (var index in this.contentAndAdsEndedListeners) {
           this.contentAndAdsEndedListeners[index]();
         }


### PR DESCRIPTION
After postroll played (or sometimes not played if it doesnot exist), player tries to replay but media source returns empty which causes error.

I implemented an extra control for checking the source.