### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-#How to become a contributor and submit patches
+# How to become a contributor and submit patches
 
-##Contributor License Agreements
+## Contributor License Agreements
 
 We'd love to accept your code patches! However, before we can take them, we have to clear a couple of legal hurdles.
 
@@ -11,13 +11,13 @@ Please fill out either the individual or corporate Contributor License Agreement
 
 Follow either of the two links above to access the appropriate CLA and instructions for how to sign and return it. Once we receive it, we'll add you to the official list of contributors and be able to accept your patches.
 
-##Submitting Patches
+## Submitting Patches
 
 - Sign a Contributor License Agreement (see above).
 - Join the [Google Media Framework discussion group](http://groups.google.com/d/forum/google-media-framework).
 - Fork the library, make the changes and send a [pull request](https://help.github.com/articles/using-pull-requests).
 - We will review your patch and add comments if any changes are required. Once any issues are resolved, we'll merge your request!
 
-#If you can't become a contributor
+# If you can't become a contributor
 
 If you can't become a contributor, but wish to share some code that illustrates an issue / shows how an issue may be fixed, then you can attach your changes on the issues page. We will use this code to troubleshoot the issue and fix it, but will not use this code in the library unless the steps to submit patches are done.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-#IMA SDK Plugin for Video.js
+# IMA SDK Plugin for Video.js
 
-##Introduction
+## Introduction
 The IMA SDK Plugin for Video.js provides a quick and easy IMA SDK integration for the Video.js player.
 
 The framework is currently in beta, allowing interested developers to try it out and send feedback before we finalize the APIs and features.
 
 To see the plugin in action, check out our [samples](//googleads.github.io/videojs-ima/).
 
-##Features
+## Features
 - Easily integrate the Google IMA SDK into Video.js to enable advertising on your video content.
 
-##Requirements
+## Requirements
   - Your favorite text editor
   - A JavaScript enabled browser
 
-##Getting started
+## Getting started
 The easiest way to get started is by using [npm](//www.npmjs.org/).
 
 ```
@@ -132,15 +132,15 @@ ad break to play. To do so:
 For a list of methods exposed by the plugin, see our full [API
 Docs](https://github.com/googleads/videojs-ima/wiki/API-Docs).
 
-##Where do I report issues?
+## Where do I report issues?
 Please report issues on the [issues page](../../issues).
 
-##Terms of Service
+## Terms of Service
 The IMA SDK plugin for Video.js uses the IMA SDK, and as such is subject to the
 [IMA SDK Terms of Service](https://developers.google.com/interactive-media-ads/terms).
 
-##Support
+## Support
 If you have questions about the framework, you can ask them at https://groups.google.com/d/forum/google-media-framework
 
-##How do I contribute?
+## How do I contribute?
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
