### PR TITLE
Fix getPlayerWidth, getPlayerHeight for Firefox

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -541,15 +541,15 @@
     }.bind(this);
 
     this.getPlayerWidth = function() {
-      var retVal = parseInt(getComputedStyle(this.player.el()).width, 10) ||
-          this.player.width();
-      return retVal;
+      var computedStyle = getComputedStyle(this.player.el()) || {};
+
+      return parseInt(computedStyle.width, 10) || this.player.width();
     }.bind(this);
 
     this.getPlayerHeight = function() {
-      var retVal = parseInt(getComputedStyle(this.player.el()).height, 10) ||
-          this.player.height();
-      return retVal;
+      var computedStyle = getComputedStyle(this.player.el()) || {};
+
+      return parseInt(computedStyle.height, 10) || this.player.height();
     }.bind(this);
 
     /**


### PR DESCRIPTION
Take into account that window.getComputedStyle can return null

Fixes #371