### PR TITLE
videojs.plugin() is deprecated in video.js 6

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -1441,6 +1441,8 @@
     });
   };
 
-  videojs.plugin('ima', init);
+  // Cross-compatibility for Video.js 5 and 6.
+  var registerPlugin = videojs.registerPlugin || videojs.plugin;
+  registerPlugin('ima', init);
 });
 


### PR DESCRIPTION
https://github.com/videojs/video.js/wiki/Video.js-6-Migration-Guide#videojsplugin

close #381