### PR TITLE
add support for setDisableCustomPlaybackForIOS10Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The plugin accepts additional settings beyond the two required settings shown in
 | contribAdsSettings     | object       | Additional settings to be passed to the contrib-ads plugin(2), used by,this IMA plugin. |
 | debug                  | boolean      | True to load the debug version of the plugin, false to load the non-debug version.,Defaults to false. |
 | disableFlashAds        | boolean      | True to disable Flash ads - Flash ads will be considered an unsupported ad type. Defaults to false. |
+| disableCustomPlaybackForIOS10Plus | boolean      | Sets whether to disable custom playback on iOS 10+ browsers. If true, ads will play inline if the content video is inline. This enables TrueView skippable ads. Defaults to false. |
 | forceNonLinearFullSlot | boolean      | True to force non-linear AdSense ads to render as linear fullslot.,If set, the content video will be paused and the non-linear text or image ad will be rendered as,fullslot. The content video will resume once the ad has been skipped or closed. |
 | locale                 | string       | Locale for ad localization. This may be any,ISO 639-1 (two-letter) or ISO 639-2,(three-letter) code(3). Defaults to 'en'. |
 | nonLinearWidth         | number       | Desired width of non-linear ads. Defaults to player width. |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The plugin accepts additional settings beyond the two required settings shown in
 | contribAdsSettings     | object       | Additional settings to be passed to the contrib-ads plugin(2), used by,this IMA plugin. |
 | debug                  | boolean      | True to load the debug version of the plugin, false to load the non-debug version.,Defaults to false. |
 | disableFlashAds        | boolean      | True to disable Flash ads - Flash ads will be considered an unsupported ad type. Defaults to false. |
-| disableCustomPlaybackForIOS10Plus | boolean      | Sets whether to disable custom playback on iOS 10+ browsers. If true, ads will play inline if the content video is inline. This enables TrueView skippable ads. Defaults to false. |
+| disableCustomPlaybackForIOS10Plus | boolean      | Sets whether to disable custom playback on iOS 10+ browsers. If true, ads will play inline if the content video is inline. Defaults to false. |
 | forceNonLinearFullSlot | boolean      | True to force non-linear AdSense ads to render as linear fullslot.,If set, the content video will be paused and the non-linear text or image ad will be rendered as,fullslot. The content video will resume once the ad has been skipped or closed. |
 | locale                 | string       | Locale for ad localization. This may be any,ISO 639-1 (two-letter) or ISO 639-2,(three-letter) code(3). Defaults to 'en'. |
 | nonLinearWidth         | number       | Desired width of non-linear ads. Defaults to player width. |

--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -1400,6 +1400,10 @@
       google.ima.settings.setDisableFlashAds(this.settings['disableFlashAds']);
     }
 
+    if (this.settings['disableCustomPlaybackForIOS10Plus']) {
+      google.ima.settings.setDisableCustomPlaybackForIOS10Plus(this.settings['disableCustomPlaybackForIOS10Plus']);
+    }
+
     createAdContainer_();
     this.adsLoader = new google.ima.AdsLoader(this.adDisplayContainer);
 
@@ -1449,4 +1453,3 @@
   var registerPlugin = videojs.registerPlugin || videojs.plugin;
   registerPlugin('ima', init);
 });
-


### PR DESCRIPTION
Gives access to the IMA setting which allows skippable ads on iOS 10+ if played inline.