### PR TITLE
Define video.js as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "videojs-doc-generator": "0.0.1"
   },
   "peerDependencies": {
-    "video.js": "*"
+    "video.js": ">=5.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-ima",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "Apache-2.0",
   "main": "./src/videojs.ima.js",
   "author": {
@@ -12,16 +12,18 @@
   "scripts": {
     "test": "python -m SimpleHTTPServer"
   },
-  "dependencies": {
-    "video.js": "~5.3",
-    "videojs-contrib-ads": "~5.0.3"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/googleads/videojs-ima"
   },
+  "dependencies": {
+    "videojs-contrib-ads": "~5.0.3"
+  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "videojs-doc-generator": "0.0.1"
+  },
+  "peerDependencies": {
+    "video.js": "*"
   }
 }


### PR DESCRIPTION
In order to work correctly with video.js v6 and Webpack it seems to be required either to increase the minimum required version of video.js, or just to define it as peer dependency (keeping the cross compatibility for video.js 5 and 6).