### PR TITLE
Added support for videojs es6 style import

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -30,6 +30,9 @@
 })(function(window, document, videojs) {
   "use strict";
 
+  // support es6 style import
+  videojs = videojs.default || videojs;
+
   var extend = function(obj) {
     var arg;
     var index;


### PR DESCRIPTION
Added support for videojs es6 style import (related to https://github.com/googleads/videojs-ima/pull/417).

btw. this could be done also client side (eg. in the webpack configuration) but in order to be more universal I guess it is better to be defined in the plugin itself (similar to https://github.com/Peer5/videojs-contrib-hls.js/blob/master/src/videojs.hlsjs.js#L154).