### PR TITLE
Added type to content source

### DIFF
--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -1337,6 +1337,11 @@
      * post-roll on iOS.
      */
     this.contentSource = '';
+
+    /**
+     * Stores the content source type so we can re-populate it manually after a
+     * post-roll.
+     */
     this.contentSourceType = '';
 
     /**

--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -405,6 +405,7 @@
       this.adsActive = true;
       this.adPlaying = true;
       this.contentSource = this.player.currentSrc();
+      this.contentSourceType = this.player.currentType();
       this.player.off('ended', this.localContentEndedListener);
       if (adEvent.getAd().getAdPodInfo().getPodIndex() != -1) {
         // Skip this call for post-roll ads
@@ -464,7 +465,10 @@
       this.adContainerDiv.style.display = 'none';
       if (this.contentComplete == true) {
         if (this.contentPlayer.src != this.contentSource) {
-          this.player.src(this.contentSource);
+          this.player.src({
+            src: this.contentSource,
+            type: this.contentSourceType
+          });
         }
         for (var index in this.contentAndAdsEndedListeners) {
           this.contentAndAdsEndedListeners[index]();
@@ -1333,6 +1337,7 @@
      * post-roll on iOS.
      */
     this.contentSource = '';
+    this.contentSourceType = '';
 
     /**
      * Local content ended listener for contentComplete.

--- a/src/videojs.ima.js
+++ b/src/videojs.ima.js
@@ -464,7 +464,9 @@
       this.allAdsCompleted = true;
       this.adContainerDiv.style.display = 'none';
       if (this.contentComplete == true) {
-        if (this.contentPlayer.src != this.contentSource) {
+        if (this.contentPlayer.src != this.contentSource) {          
+          // Avoid setted autoplay after the post-roll
+          this.player.autoplay(false);
           this.player.src({
             src: this.contentSource,
             type: this.contentSourceType


### PR DESCRIPTION
Resolved an issue with IMA plugin and HLS plugin on post-roll completed ads: without the source type the player hangs with a format not supported error.