### PR TITLE
Added adWillPlayMuted

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ the previous snippet. A summary of all settings follows:
 | adLabel                | string       | Replaces the "Advertisement" text in the ad label. Added for multilingual UI support. |
 | adsRenderingSettings   | object       | JSON object with ads rendering settings as defined in the IMA SDK,Docs(1). |
 | autoPlayAdBreaks       | boolean      | Whether or not to automatically play VMAP or ad rules ad breaks. Defaults,to true. |
+| adWillPlayMuted        | boolean      | Notifies the SDK whether the player intends to start ad while muted. Changing this setting will have no impact on ad playback. Defaults,to false. |
 | contribAdsSettings     | object       | Additional settings to be passed to the contrib-ads plugin(2), used by,this IMA plugin. |
 | debug                  | boolean      | True to load the debug version of the plugin, false to load the non-debug version.,Defaults to false. |
 | disableFlashAds        | boolean      | True to disable Flash ads - Flash ads will be considered an unsupported ad type. Defaults to false. |

--- a/src/controller.js
+++ b/src/controller.js
@@ -79,6 +79,7 @@ Controller.IMA_DEFAULTS = {
   prerollTimeout: 1000,
   adLabel: 'Advertisement',
   showControlsForJSAds: true,
+  adWillPlayMuted: false,
 };
 
 /**

--- a/src/sdk-impl.js
+++ b/src/sdk-impl.js
@@ -221,6 +221,7 @@ SdkImpl.prototype.requestAds = function() {
       (this.controller.getPlayerHeight() / 3);
 
   adsRequest.setAdWillAutoPlay(this.controller.getSettings().adWillAutoPlay);
+  adsRequest.setAdWillPlayMuted(this.controller.getSettings().adWillPlayMuted);
 
   this.adsLoader.requestAds(adsRequest);
 };


### PR DESCRIPTION
This PR makes it possible to set 

https://developers.google.com/interactive-media-ads/docs/sdks/html5/v3/apis#ima.AdsRequest.setAdWillPlayMuted

as an option