### PR TITLE
build: Change the devServer to use port 8000.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -9,7 +9,7 @@ npm install
 npm run devServer
 ```
 
-and open http://localhost:8080 in your browser. This will take you to our list
+and open http://localhost:8000 in your browser. This will take you to our list
 of samples. When you save source files, the development server will re-compile
 the JavaScript and you can refresh the page to see your changes.
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "contBuild": "watch 'npm run rollup:max' src",
-    "devServer": "forever start ./node_modules/http-server/bin/http-server && npm run contBuild",
+    "predevServer": "echo \"Starting up server on localhost:8000.\"",
+    "devServer": "forever start ./node_modules/http-server/bin/http-server -p 8000 && npm run contBuild",
     "postdevServer": "forever stop ./node_modules/http-server/bin/http-server",
     "lint": "eslint \"src/*.js\"",
     "rollup": "npm-run-all rollup:*",
@@ -19,7 +20,7 @@
     "rollup:min": "rollup -c configs/rollup.config.min.js",
     "pretest": "npm run rollup",
     "test": "npm-run-all -p -r testServer webdriver",
-    "testServer": "http-server --cors",
+    "testServer": "http-server --cors -p 8000",
     "preversion": "node scripts/preversion.js && npm run lint && npm test",
     "version": "node scripts/version.js",
     "postversion": "node scripts/postversion.js",

--- a/test/webdriver/basic.js
+++ b/test/webdriver/basic.js
@@ -46,7 +46,7 @@ browsers.browsers.forEach(function(browser) {
     });
 
     it( 'Displays ad UI ' + browser.name, async function(){
-      await driver.get('http://localhost:8080/test/webdriver/index.html?ad=linear');
+      await driver.get('http://localhost:8000/test/webdriver/index.html?ad=linear');
       await driver.findElement(By.id('content_video')).click();
       let log = await driver.findElement(By.id('log'));
       await driver.wait(until.elementTextContains(log, 'start'), 10000);
@@ -55,7 +55,7 @@ browsers.browsers.forEach(function(browser) {
     });
 
     it( 'Hides controls when ad ends ' + browser.name, async function(){
-      await driver.get('http://localhost:8080/test/webdriver/index.html?ad=linear');
+      await driver.get('http://localhost:8000/test/webdriver/index.html?ad=linear');
       await driver.findElement(By.id('content_video')).click();
       let log = await driver.findElement(By.id('log'));
       await driver.wait(until.elementTextContains(log, 'start'), 10000);
@@ -65,7 +65,7 @@ browsers.browsers.forEach(function(browser) {
     });
 
     it( 'Plays content when ad ends ' + browser.name, async function(){
-      await driver.get('http://localhost:8080/test/webdriver/index.html?ad=linear');
+      await driver.get('http://localhost:8000/test/webdriver/index.html?ad=linear');
       await driver.findElement(By.id('content_video')).click();
       let log = await driver.findElement(By.id('log'));
       await driver.wait(until.elementTextContains(log, 'start'), 10000);
@@ -76,7 +76,7 @@ browsers.browsers.forEach(function(browser) {
     });
 
     it( 'Displays skip ad button ' + browser.name, async function(){
-      await driver.get('http://localhost:8080/test/webdriver/index.html?ad=skippable');
+      await driver.get('http://localhost:8000/test/webdriver/index.html?ad=skippable');
       await driver.findElement(By.id('content_video')).click();
       let log = driver.findElement(By.id('log'));
       await driver.wait(until.elementTextContains(log, 'start'), 10000);
@@ -90,7 +90,7 @@ browsers.browsers.forEach(function(browser) {
     });
 
      it( 'VMAP: Preroll ' + browser.name, async function(){
-      await driver.get('http://localhost:8080/test/webdriver/index.html?ad=vmap_preroll');
+      await driver.get('http://localhost:8000/test/webdriver/index.html?ad=vmap_preroll');
       await driver.findElement(By.id('content_video')).click();
       let log = await driver.findElement(By.id('log'));
       await driver.wait(until.elementTextContains(log, 'start'), 10000);
@@ -100,7 +100,7 @@ browsers.browsers.forEach(function(browser) {
     });
 
     it( 'VMAP: Midroll ' + browser.name, async function(){
-      await driver.get('http://localhost:8080/test/webdriver/index.html?ad=vmap_midroll');
+      await driver.get('http://localhost:8000/test/webdriver/index.html?ad=vmap_midroll');
       await driver.findElement(By.id('content_video')).click();
       await driver.wait(until.elementIsVisible(driver.findElement(
         By.id('content_video_ima-controls-div'))), 10000);
@@ -108,7 +108,7 @@ browsers.browsers.forEach(function(browser) {
     });
 
     it( 'Nonlinear ' + browser.name, async function(){
-      await driver.get('http://localhost:8080/test/webdriver/index.html?ad=nonlinear');
+      await driver.get('http://localhost:8000/test/webdriver/index.html?ad=nonlinear');
       await driver.findElement(By.id('content_video')).click();
       let log = await driver.findElement(By.id('log'));
       await driver.wait(until.elementTextContains(log, 'start'), 10000);
@@ -120,7 +120,7 @@ browsers.browsers.forEach(function(browser) {
     });
 
     it( 'Handles ad error 303: wrappers ' + browser.name, async function(){
-      await driver.get('http://localhost:8080/test/webdriver/index.html?ad=error_303');
+      await driver.get('http://localhost:8000/test/webdriver/index.html?ad=error_303');
       let log = await driver.findElement(By.id('log'));
       await driver.wait(until.elementTextContains(log, '303'), 10000);
       await driver.sleep();

--- a/test/webdriver/content/ads.js
+++ b/test/webdriver/content/ads.js
@@ -18,16 +18,16 @@ var onAdErrorEvent = function(event) {
 };
 
 var adTags = {
-  linear: 'http://localhost:8080/test/webdriver/content/canned_ads/linear.xml',
-  skippable: 'http://localhost:8080/test/webdriver/content/canned_ads/' +
+  linear: 'http://localhost:8000/test/webdriver/content/canned_ads/linear.xml',
+  skippable: 'http://localhost:8000/test/webdriver/content/canned_ads/' +
       'skippable_linear.xml',
-  vmap_preroll: 'http://localhost:8080/test/webdriver/content/canned_ads/' +
+  vmap_preroll: 'http://localhost:8000/test/webdriver/content/canned_ads/' +
     'vmap_preroll.xml',
-  vmap_midroll: 'http://localhost:8080/test/webdriver/content/canned_ads/' +
+  vmap_midroll: 'http://localhost:8000/test/webdriver/content/canned_ads/' +
     'vmap_midroll.xml',
-  nonlinear: 'http://localhost:8080/test/webdriver/content/canned_ads/' +
+  nonlinear: 'http://localhost:8000/test/webdriver/content/canned_ads/' +
       'nonlinear.xml',
-  error_303: 'http://localhost:8080/test/webdriver/content/canned_ads/' +
+  error_303: 'http://localhost:8000/test/webdriver/content/canned_ads/' +
       'empty_wrapper.xml'
 };
 

--- a/test/webdriver/content/canned_ads/empty_wrapper.xml
+++ b/test/webdriver/content/canned_ads/empty_wrapper.xml
@@ -3,7 +3,7 @@
   <Ad id="11111">
     <Wrapper followAdditionalWrappers="true" allowMultipleAds="true" fallbackOnNoAd="true">
       <AdSystem>HandCrafted</AdSystem>
-      <VASTAdTagURI><![CDATA[http://localhost:8080/test/webdriver/content/canned_ads/empty_vast.xml]]></VASTAdTagURI>
+      <VASTAdTagURI><![CDATA[http://localhost:8000/test/webdriver/content/canned_ads/empty_vast.xml]]></VASTAdTagURI>
       <Error><![CDATA[http://www.example.com]]></Error>
       <Impression><![CDATA[http://www.example.com]]></Impression>
       <Creatives>

--- a/test/webdriver/content/canned_ads/linear.xml
+++ b/test/webdriver/content/canned_ads/linear.xml
@@ -27,8 +27,8 @@
        <ClickTracking id=""><![CDATA[http://www.example.com]]></ClickTracking>
       </VideoClicks>
       <MediaFiles>
-       <MediaFile id="GDFP" delivery="progressive" width="640" height="360" type="video/mp4" bitrate="118"><![CDATA[http://localhost:8080/test/webdriver/content/canned_ads/media/short_linear_ad.mp4]]></MediaFile>
-       <MediaFile id="GDFP" delivery="progressive" width="640" height="360" type="video/webm" bitrate="119"><![CDATA[http://localhost:8080/test/webdriver/content/canned_ads/media/short_linear_ad.webm]]></MediaFile>
+       <MediaFile id="GDFP" delivery="progressive" width="640" height="360" type="video/mp4" bitrate="118"><![CDATA[http://localhost:8000/test/webdriver/content/canned_ads/media/short_linear_ad.mp4]]></MediaFile>
+       <MediaFile id="GDFP" delivery="progressive" width="640" height="360" type="video/webm" bitrate="119"><![CDATA[http://localhost:8000/test/webdriver/content/canned_ads/media/short_linear_ad.webm]]></MediaFile>
       </MediaFiles>
      </Linear>
     </Creative>

--- a/test/webdriver/content/canned_ads/nonlinear.xml
+++ b/test/webdriver/content/canned_ads/nonlinear.xml
@@ -20,7 +20,7 @@
                      <Tracking event="creativeView"><![CDATA[http://www.example.com]]></Tracking>
                   </TrackingEvents>
                   <NonLinear id="GDFP" width="480" height="70" minSuggestedDuration="00:00:05">
-                     <StaticResource creativeType="image/png"><![CDATA[http://localhost:8080/test/webdriver/content/canned_ads/media/nonlinear_ad.png]]></StaticResource>
+                     <StaticResource creativeType="image/png"><![CDATA[http://localhost:8000/test/webdriver/content/canned_ads/media/nonlinear_ad.png]]></StaticResource>
                      <NonLinearClickThrough><![CDATA[http://www.example.com]]></NonLinearClickThrough>
                      <NonLinearClickTracking id="GDFP"><![CDATA[http://www.example.com]]></NonLinearClickTracking>
                   </NonLinear>

--- a/test/webdriver/content/canned_ads/skippable_linear.xml
+++ b/test/webdriver/content/canned_ads/skippable_linear.xml
@@ -31,8 +31,8 @@
        <ClickTracking id=""><![CDATA[http://www.example.com]]></ClickTracking>
       </VideoClicks>
       <MediaFiles>
-       <MediaFile id="GDFP" delivery="progressive" width="640" height="360" type="video/mp4" bitrate="118"><![CDATA[http://localhost:8080/test/webdriver/content/canned_ads/media/long_linear_ad.mp4]]></MediaFile>
-       <MediaFile id="GDFP" delivery="progressive" width="640" height="360" type="video/webm" bitrate="445"><![CDATA[http://localhost:8080/test/webdriver/content/canned_ads/media/long_linear_ad.webm]]></MediaFile>
+       <MediaFile id="GDFP" delivery="progressive" width="640" height="360" type="video/mp4" bitrate="118"><![CDATA[http://localhost:8000/test/webdriver/content/canned_ads/media/long_linear_ad.mp4]]></MediaFile>
+       <MediaFile id="GDFP" delivery="progressive" width="640" height="360" type="video/webm" bitrate="445"><![CDATA[http://localhost:8000/test/webdriver/content/canned_ads/media/long_linear_ad.webm]]></MediaFile>
       </MediaFiles>
      </Linear>
     </Creative>

--- a/test/webdriver/content/canned_ads/vmap_midroll.xml
+++ b/test/webdriver/content/canned_ads/vmap_midroll.xml
@@ -2,7 +2,7 @@
 <vmap:VMAP xmlns:vmap="http://www.iab.net/videosuite/vmap" version="1.0">
  <vmap:AdBreak timeOffset="00:00:05.000" breakType="linear" breakId="midroll-1">
   <vmap:AdSource id="midroll-1-ad-1" allowMultipleAds="false" followRedirects="true">
-   <vmap:AdTagURI templateType="vast3"><![CDATA[http://localhost:8080/test/webdriver/content/canned_ads/linear.xml]]></vmap:AdTagURI>
+   <vmap:AdTagURI templateType="vast3"><![CDATA[http://localhost:8000/test/webdriver/content/canned_ads/linear.xml]]></vmap:AdTagURI>
   </vmap:AdSource>
  </vmap:AdBreak>
 </vmap:VMAP>

--- a/test/webdriver/content/canned_ads/vmap_preroll.xml
+++ b/test/webdriver/content/canned_ads/vmap_preroll.xml
@@ -2,7 +2,7 @@
 <vmap:VMAP xmlns:vmap="http://www.iab.net/videosuite/vmap" version="1.0">
  <vmap:AdBreak timeOffset="start" breakType="linear" breakId="preroll">
   <vmap:AdSource id="preroll-ad-1" allowMultipleAds="false" followRedirects="true">
-   <vmap:AdTagURI templateType="vast3"><![CDATA[http://localhost:8080/test/webdriver/content/canned_ads/linear.xml]]></vmap:AdTagURI>
+   <vmap:AdTagURI templateType="vast3"><![CDATA[http://localhost:8000/test/webdriver/content/canned_ads/linear.xml]]></vmap:AdTagURI>
   </vmap:AdSource>
  </vmap:AdBreak>
 </vmap:VMAP>


### PR DESCRIPTION
Also adds predevServer, which is apparently required for postdevServer
to run.

All other projects we work on use 8000 as the test server port, so
videojs-ima using 8080 was really screwing up our Chrome autocomplete.