### PR TITLE
fix: Use contentended instead of ended event for post-rolls.

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -531,10 +531,10 @@ Controller.prototype.reset = function() {
 
 
 /**
- * Adds a listener for the 'ended' event of the video player. This should be
- * used instead of setting an 'ended' listener directly to ensure that the
- * ima can do proper cleanup of the SDK before other event listeners
- * are called.
+ * Adds a listener for the 'contentended' event of the video player. This should
+ * be used instead of setting an 'contentended' listener directly to ensure that
+ * the ima can do proper cleanup of the SDK before other event listeners are
+ * called.
  * @param {listener} listener The listener to be called when content
  *     completes.
  */

--- a/src/ima-plugin.js
+++ b/src/ima-plugin.js
@@ -51,10 +51,10 @@ const ImaPlugin = function(player, options) {
 
 
   /**
-   * Adds a listener for the 'ended' event of the video player. This should be
-   * used instead of setting an 'ended' listener directly to ensure that the
-   * ima can do proper cleanup of the SDK before other event listeners
-   * are called.
+   * Adds a listener for the 'contentended' event of the video player. This
+   * should be used instead of setting an 'contentended' listener directly to
+   * ensure that the ima can do proper cleanup of the SDK before other event
+   * listeners are called.
    * @param {listener} listener The listener to be called when content
    *     completes.
    */


### PR DESCRIPTION
Also changes reset() to verify that we're in an ad break before calling endLinearAdMode().

Addresses comments in #539 