### PR TITLE
feat: Add hard pre-roll timeout feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ the previous snippet. A summary of all settings follows:
 | adsRenderingSettings   | object       | JSON object with ads rendering settings as defined in the IMA SDK,Docs(1). |
 | autoPlayAdBreaks       | boolean      | Whether or not to automatically play VMAP or ad rules ad breaks. Defaults,to true. |
 | adWillPlayMuted        | boolean      | Notifies the SDK whether the player intends to start ad while muted. Changing this setting will have no impact on ad playback. Defaults,to false. |
-| contribAdsSettings     | object       | Additional settings to be passed to the contrib-ads plugin(2), used by,this IMA plugin. |
+| contribAdsSettings     | object       | Additional settings to be passed to the contrib-ads plugin(2), used by,this IMA plugin. These will override duplicate settings provided by the IMA plugin (e.g. contribAdsSettings.prerollTimeout will override imaOptions.prerollTimeout). |
 | debug                  | boolean      | True to load the debug version of the plugin, false to load the non-debug version.,Defaults to false. |
 | disableFlashAds        | boolean      | True to disable Flash ads - Flash ads will be considered an unsupported ad type. Defaults to false. |
 | disableCustomPlaybackForIOS10Plus | boolean      | Sets whether to disable custom playback on iOS 10+ browsers. If true, ads will play inline if the content video is inline. Defaults to false. |
@@ -103,6 +103,7 @@ the previous snippet. A summary of all settings follows:
 | numRedirects           | number       | Maximum number of VAST redirects before the subsequent redirects will be denied,,and the ad load aborted. The number of redirects directly affects latency and thus user experience.,This applies to all VAST wrapper ads. |
 | showControlsForJSAds   | boolean      | Whether or not to show the control bar for VPAID JavaScript ads. Defaults to true. |
 | showCountdown          | boolean      | Whether or not to show the ad countdown timer. Defaults to true. |
+| hardPrerollTimeout     | boolean      | When true, a pre-roll ad will never play once the prerollTimeout has been reached. When false, the prerollTimeout will trigger content to start, but the ad will still play once it is ready. Defaults to false. |
 | vpaidAllowed           | boolean      | (DEPRECATED, please use vpaidMode). |
 | vpaidMode              | VpaidMode(4) | VPAID Mode. Defaults to ENABLED. This setting,overrides vpaidAllowed. |
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "rollup:max": "rollup -c configs/rollup.config.js",
     "rollup:min": "rollup -c configs/rollup.config.min.js",
     "pretest": "npm run rollup",
+    "start": "npm run devServer",
     "test": "npm-run-all test:*",
     "test:vjs5": "npm install video.js@5.19.2 --no-save && npm-run-all -p -r testServer webdriver",
     "test:vjs6": "npm install video.js@6 --no-save && npm-run-all -p -r testServer webdriver",

--- a/src/controller.js
+++ b/src/controller.js
@@ -163,6 +163,16 @@ Controller.prototype.getContentPlayheadTracker = function() {
 
 
 /**
+ * Returns whether or not we hit a hard timeout on the pre-roll.
+ *
+ * @return {boolean} True if we hit a hard pre-roll timeout. False otherwise.
+ */
+Controller.prototype.didPrerollHardTimeout = function() {
+  return this.playerWrapper.didPrerollHardTimeout();
+}
+
+
+/**
  * Requests ads.
  */
 Controller.prototype.requestAds = function() {

--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -525,20 +525,11 @@ PlayerWrapper.prototype.onAdsReady = function() {
       this.prerollHardTimedOut = true;
       // This is ugly, but if we don't fire adsready, contrib-ads will never
       // fire readyforpreroll, and we will never call adsManager.init() and
-      // start(). So let's pretend they *did* fire readyforpreroll, which will
-      // trigger init and start, which will start the pre-roll, which will be
-      // killed in onContentPauseRequested because we just set
-      // prerollHardTimeout to true.
+      // start(). So let's pretend they *did* fire readyforpreroll, and our
+      // readyForPreroll handler will take care of skipping the pre-roll if it
+      // hard timed out.
       this.controller.onPlayerReadyForPreroll();
     }
-
-    /*if (this.vjsPlayer.ads.isInAdMode() && this.playTriggered) {
-      this.vjsPlayer.trigger('adsready');
-    } else if (!this.playTriggered) {
-      this.vjsPlayer.trigger('adsready');
-    } else {
-      this.controller.onPrerollHardTimeout();
-    }*/
   } else {
     this.vjsPlayer.trigger('adsready');
   }

--- a/src/sdk-impl.js
+++ b/src/sdk-impl.js
@@ -353,6 +353,10 @@ SdkImpl.prototype.createAdsRenderingSettings = function() {
       }
     }
   }
+  if (this.controller.didPrerollHardTimeout()) {
+    // Skip the pre-roll
+    this.adsRenderingSettings.playAdsAfterTime = 0;
+  }
 };
 
 /**
@@ -384,32 +388,9 @@ SdkImpl.prototype.onAdBreakReady = function(adEvent) {
  * @param {google.ima.AdEvent} adEvent The AdEvent thrown by the AdsManager.
  */
 SdkImpl.prototype.onContentPauseRequested = function(adEvent) {
-  // If pre-roll hard timed out, don't trigger ad mode when the pre-roll finally
-  // loads. Stil trigger it for mid- and post- rolls, though.
-  if (this.controller.didPrerollHardTimeout()) {
-    // Pre-roll hard timed out.
-    if (adEvent.getAd().getAdPodInfo() &&
-        adEvent.getAd().getAdPodInfo().getPodIndex() != 0) {
-      // Mid- or post- roll. Play it.
-      this.adsActive = true;
-      this.adPlaying = true;
-      this.controller.onAdBreakStart(adEvent);
-    } else {
-      // Pre-roll. Kill it.
-      if (adEvent.getAd().getAdPodInfo()) {
-        // Pre-roll in a VMAP response.
-        this.adsManager.discardAdBreak();
-      } else {
-        // Pre-roll, single ad.
-        this.adsManager.destroy();
-      }
-    }
-  } else {
-    // Pre-roll didn't hard timeout, or we don't care if it did or not.
-    this.adsActive = true;
-    this.adPlaying = true;
-    this.controller.onAdBreakStart(adEvent);
-  }
+  this.adsActive = true;
+  this.adPlaying = true;
+  this.controller.onAdBreakStart(adEvent);
 };
 
 
@@ -541,6 +522,11 @@ SdkImpl.prototype.onPlayerDisposed = function() {
 
 
 SdkImpl.prototype.onPlayerReadyForPreroll = function() {
+  if (this.controller.didPrerollHardTimeout() &&
+      this.adsManager.getCuePoints().length == 0) {
+    // Pre-roll hard timed out on a single ad. Don't play it.
+    return;
+  }
   if (this.autoPlayAdBreaks) {
     this.initAdsManager();
     try {


### PR DESCRIPTION
We need to talk about this one. It turns out that the pre-roll timeout in contrib-ads is actually a "soft" timeout - which means that content will start once we hit the pre-roll timeout, but **if the pre-roll loads after the timeout it will interrupt content to play**. This is why we were getting reports of content playing before ads that we couldn't reproduce - it was happening on slow connections where we hit the soft timeout. We *could* implement a "hard" timeout feature, which will prevent this. That's what this PR does. As you can see, it's a nightmare. Just look at the new CONTENT_PAUSE_REQUESTED event handler. It makes my eyes bleed. The IMA SDK and contrib-ads state machines don't really play nice together, so we're basically introducing a third state machine in our plugin to manage the two existing state machines. I hate it, it's awful, but it works. If we think this is an important enough feature to have, we can submit this PR and deal with potential support issues down the road. If we don't think this is a big enough deal to introduce this mess into our code base, then we can drop this and just tell folks we only support soft pre-roll timeouts. Let me know what you think.

Fixes #558.