### PR TITLE
fix: Resolve dangling endLinearAdMode call in onAdBreakEnd.

### DIFF
--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -444,7 +444,9 @@ PlayerWrapper.prototype.onAdBreakStart = function(adEvent) {
  */
 PlayerWrapper.prototype.onAdBreakEnd = function() {
   this.vjsPlayer.on('contentended', this.boundContentEndedListener);
-  this.vjsPlayer.ads.endLinearAdMode();
+  if (this.vjsPlayer.ads.inAdBreak()) {
+    this.vjsPlayer.ads.endLinearAdMode();
+  }
   this.vjsControls.show();
 };
 


### PR DESCRIPTION
We don't want this call to happen after post-rolls. This fixes that.

Addresses #539 