### PR TITLE
fix: Fix locale and numRedirects settings

### DIFF
--- a/src/sdk-impl.js
+++ b/src/sdk-impl.js
@@ -175,12 +175,12 @@ SdkImpl.prototype.initAdObjects = function() {
 
   if (this.controller.getSettings().locale) {
     this.adsLoader.getSettings().setLocale(
-        this.controller.getSettings.locale);
+        this.controller.getSettings().locale);
   }
 
   if (this.controller.getSettings().numRedirects) {
     this.adsLoader.getSettings().setNumRedirects(
-        this.controller.getSettings.numRedirects);
+        this.controller.getSettings().numRedirects);
   }
 
   this.adsLoader.getSettings().setPlayerType('videojs-ima');


### PR DESCRIPTION
On the new version of this plugin, locale and numRedirects settings are not passed correctly to IMA SDK, it will send "undefined" to IMA SDK and can lead to errors increase(if you use numRedirects).