### PR TITLE
Improve player dimension accuracy in certain cases

### DIFF
--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -374,9 +374,13 @@ PlayerWrapper.prototype.play = function() {
  * @return {number} The player's width.
  */
 PlayerWrapper.prototype.getPlayerWidth = function() {
-  const boundingRect = this.vjsPlayer.el().getBoundingClientRect() || {};
+  let width = (getComputedStyle(this.vjsPlayer.el()) || {}).width;
 
-  return parseInt(boundingRect.width, 10) || this.vjsPlayer.width();
+  if (!width || parseInt(width, 10) === 0) {
+    width = (this.vjsPlayer.el().getBoundingClientRect() || {}).width;
+  }
+
+  return parseInt(width, 10) || this.vjsPlayer.width();
 };
 
 
@@ -386,9 +390,13 @@ PlayerWrapper.prototype.getPlayerWidth = function() {
  * @return {number} The player's height.
  */
 PlayerWrapper.prototype.getPlayerHeight = function() {
-  const boundingRect = this.vjsPlayer.el().getBoundingClientRect() || {};
+  let height = (getComputedStyle(this.vjsPlayer.el()) || {}).height;
 
-  return parseInt(boundingRect.height, 10) || this.vjsPlayer.height();
+  if (!height || parseInt(height, 10) === 0) {
+    height = (this.vjsPlayer.el().getBoundingClientRect() || {}).height;
+  }
+
+  return parseInt(height, 10) || this.vjsPlayer.height();
 };
 
 


### PR DESCRIPTION
In PR #418, the use of `getComputedStyle` was replaced with `getBoundingClientRect` in order to support IE11. 

However, this breaks implementations where the video is being scaled using transforms because `getBoundingClientRect` returns the scaled output, not the original output. 

![image](https://user-images.githubusercontent.com/848147/40313591-dd412d00-5cdb-11e8-8678-78ca0ee4ff43.png)

This PR updates the `getPlayerWidth` and `getPlayerHeight` methods to use `getComputedStyle` and fall back to `getBoundingClientRect` when necessary. This allows us to support scaled videos, normal videos, and fluid sizing on IE11.