### PR TITLE
fix(wrapper): Resets contentComplete correctly

### DIFF
--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -595,6 +595,7 @@ PlayerWrapper.prototype.reset = function() {
   // the first playthrough of the video passed the second response's
   // mid-roll time.
   this.contentPlayheadTracker.currentTime = 0;
+  this.contentComplete = false;
 };
 
 export default PlayerWrapper;


### PR DESCRIPTION
Fixes a bug that would prevent the `nopostroll` event from being triggered, causing a delay before `contrib-ads` would fire the `ended` event on the player

Fixes #639