### PR TITLE
fix ad errors not resetting ad playback and activity state

### DIFF
--- a/src/sdk-impl.js
+++ b/src/sdk-impl.js
@@ -358,10 +358,15 @@ SdkImpl.prototype.onAdError = function(adErrorEvent) {
       adErrorEvent.getError !== undefined ?
           adErrorEvent.getError() : adErrorEvent.stack;
   window.console.warn('Ad error: ' + errorMessage);
+
   this.adsManager.destroy();
   this.controller.onAdError(adErrorEvent);
-};
 
+  // reset these so consumers don't think we are still in an ad break,
+  // but reset them after any prior cleanup happens
+  this.adsActive = false;
+  this.adPlaying = false;
+};
 
 /**
  * Listener for AD_BREAK_READY. Passes event on to publisher's listener.


### PR DESCRIPTION
Related PR for this issue: https://github.com/googleads/videojs-ima/issues/645

This fixes the ad state not being reset even though the adsManager and controller have been reset.

The use case is for clients looking to programatically control the player and ads need to know whether to call `videojs.ima.resumeAd` or `videojs.play`, which these properties provide the checks for.