### PR TITLE
Added type to content source

### DIFF
--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -467,7 +467,7 @@ PlayerWrapper.prototype.onAdError = function(adErrorEvent) {
  */
 PlayerWrapper.prototype.onAdBreakStart = function() {
   this.contentSource = this.vjsPlayer.currentSrc();
-  this.contentSourceType = this.player.currentType();
+  this.contentSourceType = this.vjsPlayer.currentType();
   this.vjsPlayer.off('contentended', this.boundContentEndedListener);
   this.vjsPlayer.ads.startLinearAdMode();
   this.vjsControls.hide();

--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -99,6 +99,12 @@ const PlayerWrapper = function(player, adsPluginSettings, controller) {
   this.contentSource = '';
 
   /**
+   * Stores the content source type so we can re-populate it manually after a
+   * post-roll.
+   */
+  this.contentSourceType = '';
+
+  /**
    * Stores data for the content playhead tracker.
    */
   this.contentPlayheadTracker = {
@@ -461,6 +467,7 @@ PlayerWrapper.prototype.onAdError = function(adErrorEvent) {
  */
 PlayerWrapper.prototype.onAdBreakStart = function() {
   this.contentSource = this.vjsPlayer.currentSrc();
+  this.contentSourceType = this.player.currentType();
   this.vjsPlayer.off('contentended', this.boundContentEndedListener);
   this.vjsPlayer.ads.startLinearAdMode();
   this.vjsControls.hide();
@@ -494,7 +501,12 @@ PlayerWrapper.prototype.onAdStart = function() {
 PlayerWrapper.prototype.onAllAdsCompleted = function() {
   if (this.contentComplete == true) {
     if (this.h5Player.src != this.contentSource) {
-      this.vjsPlayer.src(this.contentSource);
+      // Avoid setted autoplay after the post-roll
+      this.vjsPlayer.autoplay(false);
+      this.vjsPlayer.src({
+        src: this.contentSource,
+        type: this.contentSourceType
+      });
     }
     this.controller.onContentAndAdsCompleted();
   }

--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -505,7 +505,7 @@ PlayerWrapper.prototype.onAllAdsCompleted = function() {
       this.vjsPlayer.autoplay(false);
       this.vjsPlayer.src({
         src: this.contentSource,
-        type: this.contentSourceType
+        type: this.contentSourceType,
       });
     }
     this.controller.onContentAndAdsCompleted();


### PR DESCRIPTION
Resolved an issue with IMA plugin and HLS plugin on post-roll completed ads: without the source type the player hangs with a format not supported error.

Originally solved in old IMA plugin version by @valse:
https://github.com/googleads/videojs-ima/pull/433