### PR TITLE
fix: prevent event listener registration on ad error

### DIFF
--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -93,6 +93,13 @@ const PlayerWrapper = function(player, adsPluginSettings, controller) {
   this.contentEndedListeners = [];
 
   /**
+   * Flag to track if the ad errors on load
+   * If ad errors, we don't need to add an event listener for `contentended`
+   * because it is still set
+   */
+  this.adError = false;
+
+  /**
    * Stores the content source so we can re-populate it manually after a
    * post-roll on iOS.
    */
@@ -451,6 +458,7 @@ PlayerWrapper.prototype.getContentPlayheadTracker = function() {
  * @param {Object} adErrorEvent The ad error event thrown by the IMA SDK.
  */
 PlayerWrapper.prototype.onAdError = function(adErrorEvent) {
+  this.adError = true;
   this.vjsControls.show();
   const errorMessage =
       adErrorEvent.getError !== undefined ?
@@ -612,7 +620,10 @@ PlayerWrapper.prototype.addContentEndedListener = function(listener) {
  * Reset the player.
  */
 PlayerWrapper.prototype.reset = function() {
-  this.vjsPlayer.on('contentended', this.boundContentEndedListener);
+  if (!this.adError) {
+    this.vjsPlayer.on('contentended', this.boundContentEndedListener);
+  }
+  this.adError = false;
   this.vjsControls.show();
   if (this.vjsPlayer.ads.inAdBreak()) {
     this.vjsPlayer.ads.endLinearAdMode();


### PR DESCRIPTION
I am using the `addContentEnded` listener to trigger `setContentWithAdTag` in my app.

When an ad starts, this listener is removed in `PlayerWrapper.prototype.onAdBreakStart`
like so:
`  this.vjsPlayer.off('contentended', this.boundContentEndedListener);`
Then it’s reset in `PlayerWrapper.prototype.reset`

However, when an ad errors, the  `contentended` listener is never discarded, but it’s still being reset in the aforementioned code.

This results in a bug in user code, due to any listener added via `addContentEndedListener` being registered one additional time for each successive video triggered via `setContentWithAdTag` that errors on the ad. In my case, I am using this listener to trigger the next Ad/Content sequence, so it’s firing +1 times after each successive error.

This PR checks to see if an ad error occurred and then prevents the registration of successive handlers, because they are still set from earlier.