### PR TITLE
force adErrors for VAST 900:1021s

### DIFF
--- a/src/sdk-impl.js
+++ b/src/sdk-impl.js
@@ -477,6 +477,11 @@ SdkImpl.prototype.onAdComplete = function() {
  * @param {google.ima.AdEvent} adEvent The AdEvent thrown by the AdsManager.
  */
 SdkImpl.prototype.onAdLog = function(adEvent) {
+  const adData = adEvent.getAdData();
+  // force the adError event when VAST 900:1021 occurs
+  if (adData.adError && adData.adError.getErrorCode() === 1021) {
+    this.onAdError(adData.adError.getInnerError());
+  }
   this.controller.onAdLog(adEvent);
 };
 


### PR DESCRIPTION
Troubleshooting this issue (https://github.com/googleads/videojs-ima/issues/714), and attempting to fix on the videojs-ima side. In implementing the fix suggested in that discussion by the Rubicon dev team, it _looks_ like all that's needed is a check in `onAdLog` for the appropriate error code and to call onAdError explicitly.