### PR TITLE
fix(AdUi): Ensure the ad ui is reset when Controller.reset() is called.

### DIFF
--- a/src/ad-ui.js
+++ b/src/ad-ui.js
@@ -493,6 +493,14 @@ AdUi.prototype.hideAdControls = function() {
 
 
 /**
+ * Reset the UI
+ */
+AdUi.prototype.reset = function() {
+  // Hide all the advert based UI
+  this.onAllAdsCompleted();
+};
+
+/**
  * Assigns the unique id and class names to the given element as well as the
  * style class.
  * @param {HTMLElement} element Element that needs the controlName assigned.

--- a/src/controller.js
+++ b/src/controller.js
@@ -591,6 +591,7 @@ Controller.prototype.setContentWithAdsRequest =
 Controller.prototype.reset = function() {
   this.sdkImpl.reset();
   this.playerWrapper.reset();
+  this.adUi.reset();
 };
 
 


### PR DESCRIPTION
Fix a bug that leaves the Ad UI visible when switching to a stream that doesn't have a Ad Tag URL defined while an advert is currently playing.