### PR TITLE
fix : h5Player.src uses "blob:http" scheme

### DIFF
--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -515,15 +515,17 @@ PlayerWrapper.prototype.onAdStart = function() {
  */
 PlayerWrapper.prototype.onAllAdsCompleted = function() {
   if (this.contentComplete == true) {
+   if ((typeof this.h5Player.src === 'string') && (this.h5Player.src.indexOf('blob:') !== -1) ) {
     if (this.h5Player.src != this.contentSource) {
-      // Avoid setted autoplay after the post-roll
-      this.vjsPlayer.autoplay(false);
-      this.vjsPlayer.src({
-        src: this.contentSource,
-        type: this.contentSourceType,
-      });
-    }
-    this.controller.onContentAndAdsCompleted();
+       // Avoid setted autoplay after the post-roll
+       this.vjsPlayer.autoplay(false);
+       this.vjsPlayer.src({
+         src: this.contentSource,
+         type: this.contentSourceType,
+       });
+     }
+     this.controller.onContentAndAdsCompleted();
+   }
   }
 };
 

--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -515,7 +515,7 @@ PlayerWrapper.prototype.onAdStart = function() {
  */
 PlayerWrapper.prototype.onAllAdsCompleted = function() {
   if (this.contentComplete == true) {
-   if ((typeof this.h5Player.src === 'string') && (this.h5Player.src.indexOf('blob:') !== -1) ) {
+   if ((typeof this.h5Player.src === 'string') && (this.h5Player.src.indexOf('blob:') === -1) ) {
     if (this.h5Player.src != this.contentSource) {
        // Avoid setted autoplay after the post-roll
        this.vjsPlayer.autoplay(false);

--- a/src/sdk-impl.js
+++ b/src/sdk-impl.js
@@ -241,7 +241,11 @@ SdkImpl.prototype.onAdsManagerLoaded = function(adsManagerLoadedEvent) {
 
   this.adsManager = adsManagerLoadedEvent.getAdsManager(
       this.controller.getContentPlayheadTracker(), this.adsRenderingSettings);
-
+  
+  if (this.controller.getSettings().adsManagerInstantiationCallback) {
+    this.controller.getSettings().adsManagerInstantiationCallback(this.adsManager);
+  }
+ 
   this.adsManager.addEventListener(
       google.ima.AdErrorEvent.Type.AD_ERROR,
       this.onAdError.bind(this));


### PR DESCRIPTION
we cannot compare this.h5Player.src with this.contentSrc if we use https://github.com/streamroot/videojs-hlsjs-plugin (dailyMotion hlsjs engine), because this.h5Player.src uses blob-http or blob-https prefix scheme (not an-ordinary http or https prefix scheme). https://superuser.com/questions/948738/what-is-the-blobhttp-prefix-and-where-can-i-learn-more-about-this
so we must avoid reguler step for make this procedure fixed.