### PR TITLE
fix: some tracker needs adsManager instance immediately

### DIFF
--- a/src/sdk-impl.js
+++ b/src/sdk-impl.js
@@ -241,6 +241,9 @@ SdkImpl.prototype.onAdsManagerLoaded = function(adsManagerLoadedEvent) {
 
   this.adsManager = adsManagerLoadedEvent.getAdsManager(
       this.controller.getContentPlayheadTracker(), this.adsRenderingSettings);
+  if (this.controller.getSettings().adsManagerInstantiationCallback) {
+    this.controller.getSettings().adsManagerInstantiationCallback(this.adsManager);
+  }
 
   this.adsManager.addEventListener(
       google.ima.AdErrorEvent.Type.AD_ERROR,


### PR DESCRIPTION
some tracker especially IAS https://integralads.com/ (named googleimavansadapter.js), needs adsManager instance immediately, or it will be failed to call its server.