### PR TITLE
Fix to stop autoplay been switched off after a post-roll

### DIFF
--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -515,9 +515,8 @@ PlayerWrapper.prototype.onAdStart = function() {
  */
 PlayerWrapper.prototype.onAllAdsCompleted = function() {
   if (this.contentComplete == true) {
-    if (this.h5Player.src != this.contentSource) {
+    if (this.vjsPlayer.currentSrc() != this.contentSource) {
       // Avoid setted autoplay after the post-roll
-      this.vjsPlayer.autoplay(false);
       this.vjsPlayer.src({
         src: this.contentSource,
         type: this.contentSourceType,


### PR DESCRIPTION
Fix for #773. Fix to stop autoplay been switched off after a post-roll. Also correctly check if the source has been changed by checking against videojs src, not the html5 player src. 