### PR TITLE
fix: issue with initialization of adDisplayContainer

### DIFF
--- a/src/sdk-impl.js
+++ b/src/sdk-impl.js
@@ -330,7 +330,7 @@ SdkImpl.prototype.initAdsManager = function() {
     this.adsManager.setVolume(this.controller.getPlayerVolume());
     if (!this.adDisplayContainerInitialized) {
       this.adDisplayContainer.initialize();
-      this.adDisplayContainer.initialized = true;
+      this.adDisplayContainerInitialized = true;
     }
   } catch (adError) {
     this.onAdError(adError);
@@ -713,8 +713,10 @@ SdkImpl.prototype.setVolume = function(volume) {
  */
 SdkImpl.prototype.initializeAdDisplayContainer = function() {
   if (this.adDisplayContainer) {
-    this.adDisplayContainerInitialized = true;
-    this.adDisplayContainer.initialize();
+    if (!this.adDisplayContainerInitialized) {
+      this.adDisplayContainer.initialize();
+      this.adDisplayContainerInitialized = true;
+    }
   }
 };
 


### PR DESCRIPTION
Looks like a typo/confusion around adDisplayContainer's `initialize` method vs. the `adDisplayContainerInitialized` flag -- corrected here to prevent the adDisplayContainer's initialize method from being run multiple times. Adding parallel check within `initializeAdDisplayContainer`.