### PR TITLE
fix: edge case for iOS, issue with mouse enter/leave events on adContainerDiv

### DIFF
--- a/src/ad-ui.js
+++ b/src/ad-ui.js
@@ -126,14 +126,16 @@ AdUi.prototype.createAdContainer = function() {
       this.adContainerDiv, 'ima-ad-container');
   this.adContainerDiv.style.position = 'absolute';
   this.adContainerDiv.style.zIndex = 1111;
-  this.adContainerDiv.addEventListener(
+  if (!videojs.browser.IS_IOS) {
+    this.adContainerDiv.addEventListener(
       'mouseenter',
       this.showAdControls.bind(this),
       false);
-  this.adContainerDiv.addEventListener(
+    this.adContainerDiv.addEventListener(
       'mouseleave',
       this.hideAdControls.bind(this),
       false);
+  }
   this.createControls();
   this.controller.injectAdContainerDiv(this.adContainerDiv);
 };


### PR DESCRIPTION
This is a proposal for a fix to the issue described at https://github.com/googleads/videojs-ima/issues/808 [[mouseenter/mouseleave handlers prevent SKIP AD button click in iOS](https://github.com/googleads/videojs-ima/issues/808)]

The fix excludes iOS cases from adding `mouseenter` & `mouseleave` events to `adContainerDiv`, since those events introduce issues with iOS mobile safari `touch` behavior.

More info in the issue description https://github.com/googleads/videojs-ima/issues/808