### PR TITLE
Added null check

### DIFF
--- a/src/sdk-impl.js
+++ b/src/sdk-impl.js
@@ -482,6 +482,7 @@ SdkImpl.prototype.onAdLog = function(adEvent) {
  * update the ad UI.
  */
 SdkImpl.prototype.onAdPlayheadTrackerInterval = function() {
+  if (this.adsManager === null) return;
   const remainingTime = this.adsManager.getRemainingTime();
   const duration = this.currentAd.getDuration();
   let currentTime = duration - remainingTime;


### PR DESCRIPTION
We are seeing the same issue as reported here #728 

![image](https://user-images.githubusercontent.com/1250254/63253341-f50eed80-c271-11e9-89b6-f81173d031cb.png)

I cannot figure out how this raise condition can happen when I look at the code, but it does happen. So to fix the issue I propose that we add a null check to the function and bail if the adsManager is null