### PR TITLE
fix: changed to parseFloat

### DIFF
--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -384,11 +384,11 @@ PlayerWrapper.prototype.play = function() {
 PlayerWrapper.prototype.getPlayerWidth = function() {
   let width = (getComputedStyle(this.vjsPlayer.el()) || {}).width;
 
-  if (!width || parseFloat(width, 10) === 0) {
+  if (!width || parseFloat(width) === 0) {
     width = (this.vjsPlayer.el().getBoundingClientRect() || {}).width;
   }
 
-  return parseFloat(width, 10) || this.vjsPlayer.width();
+  return parseFloat(width) || this.vjsPlayer.width();
 };
 
 
@@ -400,11 +400,11 @@ PlayerWrapper.prototype.getPlayerWidth = function() {
 PlayerWrapper.prototype.getPlayerHeight = function() {
   let height = (getComputedStyle(this.vjsPlayer.el()) || {}).height;
 
-  if (!height || parseFloat(height, 10) === 0) {
+  if (!height || parseFloat(height) === 0) {
     height = (this.vjsPlayer.el().getBoundingClientRect() || {}).height;
   }
 
-  return parseFloat(height, 10) || this.vjsPlayer.height();
+  return parseFloat(height) || this.vjsPlayer.height();
 };
 
 

--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -384,11 +384,11 @@ PlayerWrapper.prototype.play = function() {
 PlayerWrapper.prototype.getPlayerWidth = function() {
   let width = (getComputedStyle(this.vjsPlayer.el()) || {}).width;
 
-  if (!width || parseInt(width, 10) === 0) {
+  if (!width || parseFloat(width, 10) === 0) {
     width = (this.vjsPlayer.el().getBoundingClientRect() || {}).width;
   }
 
-  return parseInt(width, 10) || this.vjsPlayer.width();
+  return parseFloat(width, 10) || this.vjsPlayer.width();
 };
 
 
@@ -400,11 +400,11 @@ PlayerWrapper.prototype.getPlayerWidth = function() {
 PlayerWrapper.prototype.getPlayerHeight = function() {
   let height = (getComputedStyle(this.vjsPlayer.el()) || {}).height;
 
-  if (!height || parseInt(height, 10) === 0) {
+  if (!height || parseFloat(height, 10) === 0) {
     height = (this.vjsPlayer.el().getBoundingClientRect() || {}).height;
   }
 
-  return parseInt(height, 10) || this.vjsPlayer.height();
+  return parseFloat(height, 10) || this.vjsPlayer.height();
 };
 
 


### PR DESCRIPTION
Changed parseInt to parseFloat for more accurate window resize to fix a bug where a one pixel line may appear. 

Because of discrepancies between how javascript and CSS round pixel size in the browser, this bug may still appear in certain very specific window size and browser combinations, but the frequency will be reduced.