### PR TITLE
Fixes #855

### DIFF
--- a/src/ad-ui.js
+++ b/src/ad-ui.js
@@ -402,10 +402,10 @@ AdUi.prototype.onAdBreakStart = function(adEvent) {
 
   const contentType = adEvent.getAd().getContentType();
   if ((contentType === 'application/javascript') &&
-      !this.controller.getSettings().showControlsForJSAds) {
-    this.controlsDiv.style.display = 'none';
-  } else {
+      this.controller.getSettings().showControlsForJSAds) {
     this.controlsDiv.style.display = 'block';
+  } else {
+    this.controlsDiv.style.display = 'none';
   }
   this.onAdsPlaying();
   // Start with the ad controls minimized.


### PR DESCRIPTION
Fixes #855 

That bug was caused because a wrong logic on `onAdBreakStart` function on `src/ad-ui.js` file.

Previous logic says that "if the ad is a JS ad and the option `showControlsForJSAds` is falsy then plugin should hide the controls div and elsewhere show the controls div".

The correct logic (and that is the implemented solution) is that "if the ad is a JS ad and the option `showControlsForJsAds` is *truthy* then plugin should *display* the controls div and elsewhere *hide* the controls div.

Look at the result here with the same conditions in #855:

![Fixed #855](https://user-images.githubusercontent.com/8930653/67712786-a5941e80-f992-11e9-9dfa-39467bed7759.png)
