### PR TITLE
Added option to prevent ad playing after content start

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ the previous snippet. A summary of all settings follows:
 | vastLoadTimeout        | number       | Override for default VAST load timeout in milliseconds for a single wrapper. The default timeout is 5000ms. |
 | vpaidAllowed           | boolean      | **DEPRECATED**, please use vpaidMode. |
 | vpaidMode              | VpaidMode(5) | VPAID Mode. Defaults to ENABLED. This setting,overrides vpaidAllowed. |
+| doNotPlayAdAfterContentStart | boolean | Prevent an ad from starting after the content has started. The default value is false
 
 
 (1) [IMA SDK Docs](//developers.google.com/interactive-media-ads/docs/sdks/html5/v3/apis#ima.AdsRenderingSettings)

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ the previous snippet. A summary of all settings follows:
 | vastLoadTimeout        | number       | Override for default VAST load timeout in milliseconds for a single wrapper. The default timeout is 5000ms. |
 | vpaidAllowed           | boolean      | **DEPRECATED**, please use vpaidMode. |
 | vpaidMode              | VpaidMode(5) | VPAID Mode. Defaults to ENABLED. This setting,overrides vpaidAllowed. |
-| doNotPlayAdAfterContentStart | boolean | Prevent an ad from starting after the content has started. The default value is false
+| doNotPlayAdAfterContentStart | boolean | Prevent ads from starting after the content has started if an adtimeout occurred (preroll, midroll, postroll). The default value is false
 
 
 (1) [IMA SDK Docs](//developers.google.com/interactive-media-ads/docs/sdks/html5/v3/apis#ima.AdsRenderingSettings)

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ the previous snippet. A summary of all settings follows:
 | vastLoadTimeout        | number       | Override for default VAST load timeout in milliseconds for a single wrapper. The default timeout is 5000ms. |
 | vpaidAllowed           | boolean      | **DEPRECATED**, please use vpaidMode. |
 | vpaidMode              | VpaidMode(5) | VPAID Mode. Defaults to ENABLED. This setting,overrides vpaidAllowed. |
-| doNotPlayAdAfterContentStart | boolean | Prevent ads from starting after the content has started if an adtimeout occurred (preroll, midroll, postroll). The default value is false
+| preventLateAdStart | boolean | Prevent ads from starting after the content has started if an adtimeout occurred (preroll, midroll, postroll). The default value is false
 
 
 (1) [IMA SDK Docs](//developers.google.com/interactive-media-ads/docs/sdks/html5/v3/apis#ima.AdsRenderingSettings)

--- a/src/controller.js
+++ b/src/controller.js
@@ -87,6 +87,7 @@ Controller.IMA_DEFAULTS = {
   adLabelNofN: 'of',
   showControlsForJSAds: true,
   requestMode: 'onLoad',
+  doNotPlayAdAfterContentStart: false,
 };
 
 /**
@@ -488,6 +489,13 @@ Controller.prototype.onPlayerDisposed = function() {
  */
 Controller.prototype.onPlayerReadyForPreroll = function() {
   this.sdkImpl.onPlayerReadyForPreroll();
+};
+
+/**
+ * Called if the ad times out.
+ */
+Controller.prototype.onAdTimeout = function() {
+  this.sdkImpl.onAdTimeout();
 };
 
 

--- a/src/controller.js
+++ b/src/controller.js
@@ -87,7 +87,7 @@ Controller.IMA_DEFAULTS = {
   adLabelNofN: 'of',
   showControlsForJSAds: true,
   requestMode: 'onLoad',
-  doNotPlayAdAfterContentStart: false,
+  preventLateAdStart: false,
 };
 
 /**

--- a/src/player-wrapper.js
+++ b/src/player-wrapper.js
@@ -137,6 +137,7 @@ const PlayerWrapper = function(player, adsPluginSettings, controller) {
   this.vjsPlayer.on('contentended', this.boundContentEndedListener);
   this.vjsPlayer.on('dispose', this.playerDisposedListener.bind(this));
   this.vjsPlayer.on('readyforpreroll', this.onReadyForPreroll.bind(this));
+  this.vjsPlayer.on('adtimeout', this.onAdTimeout.bind(this));
   this.vjsPlayer.ready(this.onPlayerReady.bind(this));
 
   if (this.controller.getSettings().requestMode === 'onPlay') {
@@ -270,6 +271,12 @@ PlayerWrapper.prototype.onReadyForPreroll = function() {
   this.controller.onPlayerReadyForPreroll();
 };
 
+/**
+ * Detects if the ad has timed out.
+ */
+PlayerWrapper.prototype.onAdTimeout = function() {
+  this.controller.onAdTimeout();
+};
 
 /**
  * Called when the player fires its 'ready' event.

--- a/src/sdk-impl.js
+++ b/src/sdk-impl.js
@@ -108,6 +108,11 @@ const SdkImpl = function(controller) {
   this.contentCompleteCalled = false;
 
   /**
+   * True if the ad has timed out.
+   */
+  this.isAdTimedOut = false;
+
+  /**
    * Stores the dimensions for the ads manager.
    */
   this.adsManagerDimensions = {
@@ -301,7 +306,14 @@ SdkImpl.prototype.onAdsManagerLoaded = function(adsManagerLoadedEvent) {
     this.initAdsManager();
   }
 
-  this.controller.onAdsReady();
+  const {doNotPlayAdAfterContentStart} = this.controller.getSettings();
+
+  if (!doNotPlayAdAfterContentStart) {
+    this.controller.onAdsReady();
+  } else if (doNotPlayAdAfterContentStart &&
+    !this.isAdTimedOut) {
+    this.controller.onAdsReady();
+  }
 
   if (this.controller.getSettings().adsManagerLoadedCallback) {
     this.controller.getSettings().adsManagerLoadedCallback();
@@ -556,6 +568,10 @@ SdkImpl.prototype.onPlayerReadyForPreroll = function() {
       this.onAdError(adError);
     }
   }
+};
+
+SdkImpl.prototype.onAdTimeout = function() {
+  this.isAdTimedOut = true;
 };
 
 SdkImpl.prototype.onPlayerReady = function() {

--- a/src/sdk-impl.js
+++ b/src/sdk-impl.js
@@ -306,11 +306,11 @@ SdkImpl.prototype.onAdsManagerLoaded = function(adsManagerLoadedEvent) {
     this.initAdsManager();
   }
 
-  const {doNotPlayAdAfterContentStart} = this.controller.getSettings();
+  const {preventLateAdStart} = this.controller.getSettings();
 
-  if (!doNotPlayAdAfterContentStart) {
+  if (!preventLateAdStart) {
     this.controller.onAdsReady();
-  } else if (doNotPlayAdAfterContentStart &&
+  } else if (preventLateAdStart &&
     !this.isAdTimedOut) {
     this.controller.onAdsReady();
   }


### PR DESCRIPTION
We are sometimes seeing ads starting after the content is already playing.

Others have reported this issue as well

https://github.com/googleads/videojs-ima/issues/558
https://github.com/googleads/videojs-ima/issues/167

People have solved the issue with various hacks, but I found this in the videojs-contrib-ads plugin.

http://videojs.github.io/videojs-contrib-ads/integrator/options.html

> Some ad plugins may want to play a preroll ad even after the timeout has expired and content has begun playing. To facilitate this, videojs-contrib-ads will respond to an adsready event during content playback with a readyforpreroll event. If you want to avoid this behavior, make sure your plugin does not send adsready after adtimeout

This PR implements this functionality

I´m not sure about the name doNotPlayAdAfterContentStart though. But have not been able to find a better name.