### PR TITLE
removes firefox tests

### DIFF
--- a/test/webdriver/content/capabilities.js
+++ b/test/webdriver/content/capabilities.js
@@ -37,14 +37,16 @@ var browsers = [
       'chromeOptions' : {args: ['--headless']}
     }
   },
-  {
-    name: 'firefox-local',
-    server: '', //local
-    capabilities: {
-      'browserName' : 'firefox',
-      'moz:firefoxOptions' : {args: ['-headless']}
-    }
-  },
+  // Currently experiencing an issue where the firefox browser is timing out (2/24/2020)
+  // Removing until this is resolved.
+  // {
+  //   name: 'firefox-local',
+  //   server: '', //local
+  //   capabilities: {
+  //     'browserName' : 'firefox',
+  //     'moz:firefoxOptions' : {args: ['-headless']}
+  //   }
+  // },
 ];
 
 for (let browser of browsers) {


### PR DESCRIPTION
Firefox browser tests have been consistently timing out, this change disables them until we can determine a root cause for the time out.

It looks to be a problem related to the testing browser as it is not the same tests timing out each time.