### PR TITLE
adds setting disableAdControls

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,30 +142,31 @@ the previous snippet. A summary of all settings follows:
 
 | Settings | Type | Description |
 |----------|------|-------------|
-| adTagUrl               | string       | A URL which returns a VAST, VMAP or ad rules,response. This will override adsResponse. |
-| adsResponse            | string       | The VAST, VMAP, or ad rules response to use,in lieu of fetching one an ad tag. This is overridden if adTagUrl is set. |
-| adsRequest             | object       | JSON object with ads request properties defined in the IMA SDK Docs(2). Properties set here that can also be provided elsewhere (e.g. adTagUrl) will override those other settings. |
 | adLabel                | string       | Replaces the "Advertisement" text in the ad label. Added for multilingual UI support. |
 | adLabelNofN            | string       | Replaces the "of" text in the ad label (e.g. ... (1 of 2) ...). Added for multilingual UI support. |
+| adTagUrl               | string       | A URL which returns a VAST, VMAP or ad rules response. This will override adsResponse. |
 | adsRenderingSettings   | object       | JSON object with ads rendering settings as defined in the IMA SDK Docs(1). |
-| autoPlayAdBreaks       | boolean      | Whether or not to automatically play VMAP or ad rules ad breaks. Defaults,to true. |
-| **deprecated** adWillPlayMuted        | boolean      | Notifies the SDK whether the player intends to start ad while muted. Changing this setting will have no impact on ad playback. Defaults,to false. |
-| contribAdsSettings     | object       | Additional settings to be passed to the contrib-ads plugin(3), used by,this IMA plugin. |
-| debug                  | boolean      | True to load the debug version of the plugin, false to load the non-debug version.,Defaults to false. |
-| disableFlashAds        | boolean      | True to disable Flash ads - Flash ads will be considered an unsupported ad type. Defaults to false. |
+| adsResponse            | string       | The VAST, VMAP, or ad rules response to use in lieu of fetching one an ad tag. This is overridden if adTagUrl is set. |
+| adsRequest             | object       | JSON object with ads request properties defined in the IMA SDK Docs(2). Properties set here that can also be provided elsewhere (e.g. adTagUrl) will override those other settings. |
+| autoPlayAdBreaks       | boolean      | Whether or not to automatically play VMAP or ad rules ad breaks. Defaults to true. |
+| **deprecated** adWillPlayMuted        | boolean      | Notifies the SDK whether the player intends to start ad while muted. Changing this setting will have no impact on ad playback. Defaults to false. |
+| contribAdsSettings     | object       | Additional settings to be passed to the contrib-ads plugin(3) used by this IMA plugin. |
+| debug                  | boolean      | True to load the debug version of the plugin, false to load the non-debug version. Defaults to false. |
+| disableAdControls      | boolean      | True to hide the ad controls(play/pause, volume, and fullscreen buttons) during ad playback. Defaults to false. |
 | disableCustomPlaybackForIOS10Plus | boolean      | Sets whether to disable custom playback on iOS 10+ browsers. If true, ads will play inline if the content video is inline. Defaults to false. |
-| forceNonLinearFullSlot | boolean      | True to force non-linear AdSense ads to render as linear fullslot.,If set, the content video will be paused and the non-linear text or image ad will be rendered as,fullslot. The content video will resume once the ad has been skipped or closed. |
+| disableFlashAds        | boolean      | True to disable Flash ads - Flash ads will be considered an unsupported ad type. Defaults to false. |
+| forceNonLinearFullSlot | boolean      | True to force non-linear AdSense ads to render as linear fullslot. If set, the content video will be paused and the non-linear text or image ad will be rendered as fullslot. The content video will resume once the ad has been skipped or closed. |
 | id                     | string       | **DEPRECATED** as of v.1.5.0, no longer used or required. |
 | locale                 | string       | Locale for ad localization. The supported locale codes can be found in [Localizing for Language and Locale](//developers.google.com/interactive-media-ads/docs/sdks/html5/localization)|
-| nonLinearWidth         | number       | Desired width of non-linear ads. Defaults to player width. |
 | nonLinearHeight        | number       | Desired height for non-linear ads. Defaults to 1/3 player height. |
-| numRedirects           | number       | Maximum number of VAST redirects before the subsequent redirects will be denied,,and the ad load aborted. The number of redirects directly affects latency and thus user experience.,This applies to all VAST wrapper ads. |
+| nonLinearWidth         | number       | Desired width of non-linear ads. Defaults to player width. |
+| numRedirects           | number       | Maximum number of VAST redirects before the subsequent redirects will be denied and the ad load aborted. The number of redirects directly affects latency and thus user experience. This applies to all VAST wrapper ads. |
+| preventLateAdStart | boolean | Prevent ads from starting after the content has started if an adtimeout occurred (preroll, midroll, postroll). The default value is false
 | showControlsForJSAds   | boolean      | Whether or not to show the control bar for VPAID JavaScript ads. Defaults to true. |
 | showCountdown          | boolean      | Whether or not to show the ad countdown timer. Defaults to true. |
 | vastLoadTimeout        | number       | Override for default VAST load timeout in milliseconds for a single wrapper. The default timeout is 5000ms. |
 | vpaidAllowed           | boolean      | **DEPRECATED**, please use vpaidMode. |
-| vpaidMode              | VpaidMode(5) | VPAID Mode. Defaults to ENABLED. This setting,overrides vpaidAllowed. |
-| preventLateAdStart | boolean | Prevent ads from starting after the content has started if an adtimeout occurred (preroll, midroll, postroll). The default value is false
+| vpaidMode              | VpaidMode(5) | VPAID Mode. Defaults to ENABLED. This setting overrides vpaidAllowed. |
 
 
 (1) [IMA SDK Docs](//developers.google.com/interactive-media-ads/docs/sdks/html5/v3/apis#ima.AdsRenderingSettings)

--- a/src/ad-ui.js
+++ b/src/ad-ui.js
@@ -491,7 +491,10 @@ AdUi.prototype.onPlayerVolumeChanged = function(volume) {
  * Shows ad controls on mouseover.
  */
 AdUi.prototype.showAdControls = function() {
-  this.addClass(this.controlsDiv, 'ima-controls-div-showing');
+  const {disableAdControls} = this.controller.getSettings();
+  if(!disableAdControls) {
+    this.addClass(this.controlsDiv, 'ima-controls-div-showing');
+  }
 };
 
 

--- a/src/ad-ui.js
+++ b/src/ad-ui.js
@@ -492,7 +492,7 @@ AdUi.prototype.onPlayerVolumeChanged = function(volume) {
  */
 AdUi.prototype.showAdControls = function() {
   const {disableAdControls} = this.controller.getSettings();
-  if(!disableAdControls) {
+  if (!disableAdControls) {
     this.addClass(this.controlsDiv, 'ima-controls-div-showing');
   }
 };

--- a/src/controller.js
+++ b/src/controller.js
@@ -80,14 +80,15 @@ const Controller = function(player, options) {
 
 
 Controller.IMA_DEFAULTS = {
-  debug: false,
-  timeout: 5000,
-  prerollTimeout: 1000,
   adLabel: 'Advertisement',
   adLabelNofN: 'of',
-  showControlsForJSAds: true,
-  requestMode: 'onLoad',
+  debug: false,
+  disableAdControls: false,
+  prerollTimeout: 1000,
   preventLateAdStart: false,
+  requestMode: 'onLoad',
+  showControlsForJSAds: true,
+  timeout: 5000,
 };
 
 /**


### PR DESCRIPTION
Adds a setting to hide the plugin owned ad controls. Specifically the play/pause, volume, and full-screen buttons.

Also, re-alphabetizes readme settings and settings defaults.

Fix for issue #756