### PR TITLE
bugfix for setting vpaid mode to disabled

### DIFF
--- a/src/sdk-impl.js
+++ b/src/sdk-impl.js
@@ -165,7 +165,7 @@ SdkImpl.prototype.initAdObjects = function() {
     this.adsLoader.getSettings().setVpaidMode(
         google.ima.ImaSdkSettings.VpaidMode.DISABLED);
   }
-  if (this.controller.getSettings().vpaidMode) {
+  if (this.controller.getSettings().vpaidMode !== undefined) {
     this.adsLoader.getSettings().setVpaidMode(
         this.controller.getSettings().vpaidMode);
   }


### PR DESCRIPTION
Fixes an issue where VpaidMode.DISABLED could not be set because google.ima.ImaSdkSettings.VpaidMode.DISABLED = 0.