### PR TITLE
added pause/resume events for non-mobile

### DIFF
--- a/src/sdk-impl.js
+++ b/src/sdk-impl.js
@@ -290,16 +290,12 @@ SdkImpl.prototype.onAdsManagerLoaded = function(adsManagerLoadedEvent) {
   this.adsManager.addEventListener(
       google.ima.AdEvent.Type.LOG,
       this.onAdLog.bind(this));
-
-  if (this.controller.getIsMobile()) {
-    // Show/hide controls on pause and resume (triggered by tap).
-    this.adsManager.addEventListener(
-        google.ima.AdEvent.Type.PAUSED,
-        this.onAdPaused.bind(this));
-    this.adsManager.addEventListener(
-        google.ima.AdEvent.Type.RESUMED,
-        this.onAdResumed.bind(this));
-  }
+  this.adsManager.addEventListener(
+      google.ima.AdEvent.Type.PAUSED,
+      this.onAdPaused.bind(this));
+  this.adsManager.addEventListener(
+      google.ima.AdEvent.Type.RESUMED,
+      this.onAdResumed.bind(this));
 
   this.controller.playerWrapper.vjsPlayer.trigger({
     type: 'ads-manager',


### PR DESCRIPTION
Previously [onAdsPaused](https://github.com/googleads/videojs-ima/blob/master/src/ad-ui.js#L244-L249) only happened on mobile. This changes it to always happen to be in line with changes to [IMA ad pause behavior](https://ads-developers.googleblog.com/2020/09/changes-to-pause-behavior-in.html)