### PR TITLE
Fix compatibility for Videojs-8

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@hapi/cryptiles": "^5.1.0",
     "can-autoplay": "^3.0.2",
     "extend": ">=3.0.2",
-    "videojs-contrib-ads": "^7.0.0"
+    "videojs-contrib-ads": "^6.9.0 || ^7"
   },
   "devDependencies": {
     "axios": "^1.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-ima",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "license": "Apache-2.0",
   "main": "./dist/videojs.ima.js",
   "module": "./dist/videojs.ima.es.js",
@@ -48,7 +48,7 @@
     "@hapi/cryptiles": "^5.1.0",
     "can-autoplay": "^3.0.2",
     "extend": ">=3.0.2",
-    "videojs-contrib-ads": "^6.9.0"
+    "videojs-contrib-ads": "^7.0.0"
   },
   "devDependencies": {
     "axios": "^1.6.4",


### PR DESCRIPTION
**v2.3.0** breaks support for videojs8
Reference: https://github.com/googleads/videojs-ima/compare/v2.2.0...v2.3.0

Fixes #1168

Updated package version and dependency version in package.json

`videojs-ima@2.3.0` needs `videojs-contrib-ads` version `6.*` which requires video.js version `7.x`. Hence, this makes it incompatible with videojs 8.

Apparently, this issue is introduced in `v2.3.0`. It worked fine in `videojs-ima@2.2.0`.