### PR TITLE
Fix incorrect streamManager casing causing undefined error

### DIFF
--- a/src/dai/sdk-impl.js
+++ b/src/dai/sdk-impl.js
@@ -340,7 +340,7 @@ SdkImpl.prototype.onPlayerDisposed = function() {
  * plugin.
  */
 SdkImpl.prototype.getStreamManager = function() {
-  return this.StreamManager;
+  return this.streamManager;
 };
 
 
@@ -348,8 +348,8 @@ SdkImpl.prototype.getStreamManager = function() {
  * Reset the SDK implementation.
  */
 SdkImpl.prototype.reset = function() {
-  if (this.StreamManager) {
-    this.StreamManager.reset();
+  if (this.streamManager) {
+    this.streamManager.reset();
   }
 };
 


### PR DESCRIPTION
Hi 🙂 
While reviewing the DAI-related code, I noticed that the `getStreamManager` and `reset` methods were incorrectly using `this.StreamManager` (with an uppercase `S`).

However, in `sdk-impl.js`, the actual property is defined as `this.streamManager` (lowercase `s`), which causes an `undefined` error when accessed.

Based on the surrounding code in `sdk-impl.js`, the `onPlayerDisposed` method also uses `this.streamManager` (lowercase `s`), indicating that this is simply a typo 🧐

This issue is easy to reproduce — calling `imaDai.getStreamManager()` from a Video.js instance returns undefined, since `this.StreamManager` does not exist.