### PR TITLE
Fix ad volume slider mute state

### DIFF
--- a/src/client-side/ad-ui.js
+++ b/src/client-side/ad-ui.js
@@ -360,7 +360,7 @@ AdUi.prototype.changeVolume = function(event) {
   // Bounds value 0-100 if mouse is outside slider region.
   percent = Math.min(Math.max(percent, 0), 100);
   this.sliderLevelDiv.style.width = percent + '%';
-  if (this.percent == 0) {
+  if (percent == 0) {
     this.addClass(this.muteDiv, 'ima-muted');
     this.removeClass(this.muteDiv, 'ima-non-muted');
   } else {


### PR DESCRIPTION
Fixes the ad volume slider mute state when dragging the slider to zero.

`AdUi.prototype.changeVolume` calculates the current slider percentage in the local `percent` variable, but the mute state check was using `this.percent`, which is not set.This caused the muted UI state to be based on an undefined property instead of the current slider value.

This appears to be a typo: `changeVolume` computes the current slider percentage in the local `percent` variable, but the mute state check reads `this.percent` instead.